### PR TITLE
Fix static and dynamic fields in arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,5 +325,37 @@ The main concept is to first create a model of your data structure and then util
     // { ab: { x: -2, y: -1 }, xyz: { x: 0, y: 1, z: 2 } }
 
 ```
+```typescript
+{
+    // Value, static array, dynamic array
+    const model = `[
+        i8,         // 1 byte
+        i8[2],      // 2 bytes static array
+        i8[i16]     // i16 bytes dynamic array
+    ]`;
+
+    const cStruct = new CStructBE(model);
+
+    console.log(cStruct.jsonModel);
+    // ["i8","i8.2","i8.i16"]
+    console.log(cStruct.modelClone);
+    // [ 'i8', 'i8.2', 'i8.i16' ]
+
+    const data = [
+        0x01,
+        [0x02, 0x03],
+        [0x04, 0x05, 0x06, 0x07],
+    ];
+    const {buffer} = cStruct.make(data);
+
+    console.log(buffer.toString('hex'));
+    // 010203000404050607
+    // 01 02_03 0004_04_05_06_07
+
+    const {struct: extractedData} = cStruct.read(buffer);
+    console.log(extractedData);
+    // [ 1, [ 2, 3 ], [ 4, 5, 6, 7 ] ]
+}
+```
 
 ### [TODO](https://github.com/MrHIDEn/cstruct/blob/main/doc/TODO.md)

--- a/examples/dynamic-model.ts
+++ b/examples/dynamic-model.ts
@@ -1,6 +1,37 @@
 import { CStructBE } from "../src";
 
 {
+    // Value, static array, dynamic array
+    const model = `[
+        i8,         // 1 byte
+        i8[2],      // 2 bytes static array
+        i8[i16]     // i16 bytes dynamic array
+    ]`;
+
+    const cStruct = new CStructBE(model);
+
+    console.log(cStruct.jsonModel);
+    // ["i8","i8.2","i8.i16"]
+    console.log(cStruct.modelClone);
+    // [ 'i8', 'i8.2', 'i8.i16' ]
+
+    const data = [
+        0x01,
+        [0x02, 0x03],
+        [0x04, 0x05, 0x06, 0x07],
+    ];
+    const {buffer} = cStruct.make(data);
+
+    console.log(buffer.toString('hex'));
+    // 010203000404050607
+    // 01 02_03 0004_04_05_06_07
+
+    const {struct: extractedData} = cStruct.read(buffer);
+    console.log(extractedData);
+    // [ 1, [ 2, 3 ], [ 4, 5, 6, 7 ] ]
+}
+
+{
     // Dynamic (length) array
     const model = {
         abc: "i8[i16]",

--- a/examples/string-model.ts
+++ b/examples/string-model.ts
@@ -11,7 +11,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
     // where the struct and data types are defined in a model
     const cStruct = new CStructBE(`{a:u8, b:u16, c:u32}`);
 
-    const { struct } = cStruct.read(buffer);
+    const {struct} = cStruct.read(buffer);
 
     console.log(struct);
     // { a: 1, b: 2, c: 3 }
@@ -27,7 +27,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
     // Read a struct from a buffer
     // where the struct and data types are defined in a model
     const cStruct = new CStructLE(`{a: u8, b: u16, c: u32}`);
-    const { struct } = cStruct.read(buffer);
+    const {struct} = cStruct.read(buffer);
 
     console.log(struct);
     // { a: 1, b: 2, c: 3 }
@@ -45,7 +45,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
         {a: b8, b: b16, c: b32, d: b64}
     ]`);
 
-    const { struct } = cStruct.read(buffer);
+    const {struct} = cStruct.read(buffer);
 
     console.log(struct);
     // [
@@ -62,7 +62,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
 
     const cStruct = new CStructBE(`[u16, u16, u16]`);
 
-    const { struct } = cStruct.read(buffer);
+    const {struct} = cStruct.read(buffer);
 
     console.log(struct);
     // [ 1, 2, 3 ]
@@ -76,7 +76,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
 
     const cStruct = new CStructLE(`[u16, u16, u16]`);
 
-    const { struct } = cStruct.read(buffer);
+    const {struct} = cStruct.read(buffer);
 
     console.log(struct);
     // [ 1, 2, 3 ]
@@ -90,7 +90,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
 
     const cStruct = new CStructBE(`{ error: {code: u16, message: s20} }`);
 
-    const { struct, offset, size, toAtoms } = cStruct.read(buffer);
+    const {struct, offset, size, toAtoms} = cStruct.read(buffer);
 
     console.log(struct);
     // { error: { code: 15, message: 'abc' } }
@@ -111,7 +111,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
     const cStruct = new CStructLE(`[u16, u16, u16]`);
 
     // Read with offset 3
-    const { struct } = cStruct.read(buffer, 3);
+    const {struct} = cStruct.read(buffer, 3);
 
     console.log(struct);
     // [ 1, 2, 3 ]
@@ -121,7 +121,7 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
     // Make buffer from struct based on model
     const cStruct = new CStructBE(`{ error: {code: u16, message: s20} }`);
 
-    const { buffer, offset, size, toAtoms } = cStruct.make({ error: { code: 10, message: 'xyz' } });
+    const {buffer, offset, size, toAtoms} = cStruct.make({error: {code: 10, message: 'xyz'}});
 
     console.log(buffer.toString('hex'));
     // 000a78797a0000000000000000000000000000000000
@@ -140,9 +140,9 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
 
     const cStruct = new CStructBE(`{ error: {code: u16, message: s20} }`);
 
-    const { buffer: b, offset, size, toAtoms } = cStruct.write(
+    const {buffer: b, offset, size, toAtoms} = cStruct.write(
         buffer,
-        { error: { code: 0x44, message: 'xyz' } },
+        {error: {code: 0x44, message: 'xyz'}},
         3
     );
 
@@ -162,14 +162,14 @@ import { hexToBuffer, CStructBE, CStructLE } from "../src";
     const model = `{u8 a,b;}`;
     const cStruct = new CStructBE(model);
 
-    const makeStruct = { a: 1, b: 2 };
-    const { buffer: structBuffer } = cStruct.make(
+    const makeStruct = {a: 1, b: 2};
+    const {buffer: structBuffer} = cStruct.make(
         makeStruct
     );
     console.log(structBuffer.toString('hex'));
     // 0102
 
-    const { struct: readStruct } = cStruct.read(structBuffer);
+    const {struct: readStruct} = cStruct.read(structBuffer);
     console.log(readStruct);
     // { a: 1, b: 2 }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrhiden/cstruct",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "For packing and unpacking bytes (C like structures) in/from Buffer based on Object/Array type for parsing.",
   "--comments": [
     "Developed from 31.01.2019"

--- a/src/read-write-base.ts
+++ b/src/read-write-base.ts
@@ -2,13 +2,21 @@ import { Type } from "./types";
 
 
 export class ReadWriteBase {
-    protected _dynamicLengthRegex = /^(?<itemKey>\w+)\.(?<itemLengthType>\w+)$/;
+    protected _dynamicLengthRegex = /^(?<dynamicKey>\w+)\.(?<dynamicLength>\w+)$/;
 
-    protected _dynamicLengthMatch(key: string) {
-        return key.match(this._dynamicLengthRegex);
+    protected _dynamicGroupsMatch(key: string) {
+        return key.match(this._dynamicLengthRegex)?.groups;
     }
 
     protected _itemTypeIsStringOrBuffer(itemsType: Type) {
         return ['s', 'buf'].includes(itemsType as string);
+    }
+
+    protected _getSize(size: string): {isNumber: boolean, staticSize: number} {
+        const value = +size;
+        return {
+            isNumber: !Number.isNaN(value),
+            staticSize: value
+        };
     }
 }

--- a/tests/buffer.test.ts
+++ b/tests/buffer.test.ts
@@ -23,7 +23,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = {r: hexToBuffer('12_34_56')};
 
                 const result = cStruct.read(buffer);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.struct).toEqual(expected);
                 expect(result.offset).toBe(3);
                 expect(result.size).toBe(3);
@@ -62,7 +62,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = {r: hexToBuffer('12_34_56')};
 
                 const result = cStruct.read(buffer, 2);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.struct).toEqual(expected);
                 expect(result.offset).toBe(5);
                 expect(result.size).toBe(3);
@@ -103,7 +103,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = hexToBuffer('12_34_56');
 
                 const result = cStruct.make(struct);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(3);
                 expect(result.size).toBe(3);
@@ -120,6 +120,36 @@ describe('buf - buffer - Buffer', () => {
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(4);
                 expect(result.size).toBe(4);
+            });
+
+            it(`should make and truncate static buffer`, () => {
+                const model = {staticBuffer: 'buf[2]'};
+                const cStruct = new CStructBE(model);
+                const struct = {
+                    staticBuffer: Buffer.from("abcdef")
+                };
+                const expected = hexToBuffer('6162');
+
+                const result = cStruct.make(struct);
+                expect(cStruct.modelClone).toEqual({'staticBuffer.2': 'buf'});
+                expect(result.buffer).toEqual(expected);
+                expect(result.offset).toBe(2);
+                expect(result.size).toBe(2);
+            });
+
+            it(`should make and truncate static string`, () => {
+                const model = {staticString: 'string[2]'};
+                const cStruct = new CStructBE(model);
+                const struct = {
+                    staticString: "abcdef"
+                };
+                const expected = hexToBuffer('6162');
+
+                const result = cStruct.make(struct);
+                expect(cStruct.modelClone).toEqual({'staticString.2': 's'});
+                expect(result.buffer).toEqual(expected);
+                expect(result.offset).toBe(2);
+                expect(result.size).toBe(2);
             });
         });
 
@@ -146,7 +176,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = hexToBuffer('12_34_56');
 
                 const result = cStruct.write(buffer, struct);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(3);
                 expect(result.size).toBe(3);
@@ -188,7 +218,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = hexToBuffer('7777 12_34_56');
 
                 const result = cStruct.write(buffer, struct, 2);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(5);
                 expect(result.size).toBe(3);
@@ -232,7 +262,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = {r: hexToBuffer('12_34_56')};
 
                 const result = cStruct.read(buffer);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.struct).toEqual(expected);
                 expect(result.offset).toBe(3);
                 expect(result.size).toBe(3);
@@ -271,7 +301,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = {r: hexToBuffer('12_34_56')};
 
                 const result = cStruct.read(buffer, 2);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.struct).toEqual(expected);
                 expect(result.offset).toBe(5);
                 expect(result.size).toBe(3);
@@ -312,7 +342,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = hexToBuffer('12_34_56');
 
                 const result = cStruct.make(struct);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(3);
                 expect(result.size).toBe(3);
@@ -329,6 +359,36 @@ describe('buf - buffer - Buffer', () => {
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(4);
                 expect(result.size).toBe(4);
+            });
+
+            it(`should make and truncate static buffer`, () => {
+                const model = {staticBuffer: 'buf[2]'};
+                const cStruct = new CStructLE(model);
+                const struct = {
+                    staticBuffer: Buffer.from("abcdef")
+                };
+                const expected = hexToBuffer('6162');
+
+                const result = cStruct.make(struct);
+                expect(cStruct.modelClone).toEqual({'staticBuffer.2': 'buf'});
+                expect(result.buffer).toEqual(expected);
+                expect(result.offset).toBe(2);
+                expect(result.size).toBe(2);
+            });
+
+            it(`should make and truncate static string`, () => {
+                const model = {staticString: 'string[2]'};
+                const cStruct = new CStructLE(model);
+                const struct = {
+                    staticString: "abcdef"
+                };
+                const expected = hexToBuffer('6162');
+
+                const result = cStruct.make(struct);
+                expect(cStruct.modelClone).toEqual({'staticString.2': 's'});
+                expect(result.buffer).toEqual(expected);
+                expect(result.offset).toBe(2);
+                expect(result.size).toBe(2);
             });
         });
 
@@ -355,7 +415,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = hexToBuffer('12_34_56');
 
                 const result = cStruct.write(buffer, struct);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(3);
                 expect(result.size).toBe(3);
@@ -397,7 +457,7 @@ describe('buf - buffer - Buffer', () => {
                 const expected = hexToBuffer('7777 12_34_56');
 
                 const result = cStruct.write(buffer, struct, 2);
-                expect(cStruct.modelClone).toEqual({r: 'buf3'});
+                expect(cStruct.modelClone).toEqual({'r.3': 'buf'});
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(5);
                 expect(result.size).toBe(3);

--- a/tests/dynamic-array.test.ts
+++ b/tests/dynamic-array.test.ts
@@ -1,4 +1,4 @@
-import { hexToBuffer, CStructBE, CStructLE } from "../src/tests";
+import { hexToBuffer, CStructBE, CStructLE } from "../src";
 
 
 describe('dynamic array', () => {
@@ -173,6 +173,22 @@ describe('dynamic array', () => {
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(10);
                 expect(result.size).toBe(10);
+            });
+
+            it(`should make [i8, i8[2], i8[i16]]`, () => {
+                const model = `[i8, i8[2], i8[i16]]`;
+                const cStruct = new CStructBE(model);
+                const struct = [
+                    0x01,
+                    [0x02, 0x03],
+                    [0x04, 0x05, 0x06, 0x07],
+                ];
+                const expected = hexToBuffer('01 02_03 0004_04_05_06_07');
+
+                const result = cStruct.make(struct);
+                expect(result.buffer).toEqual(expected);
+                expect(result.offset).toBe(9);
+                expect(result.size).toBe(9);
             });
         });
 
@@ -476,6 +492,22 @@ describe('dynamic array', () => {
                 expect(result.buffer).toEqual(expected);
                 expect(result.offset).toBe(10);
                 expect(result.size).toBe(10);
+            });
+
+            it(`should make [i8, i8[2], i8[i16]]`, () => {
+                const model = `[i8, i8[2], i8[i16]]`;
+                const cStruct = new CStructLE(model);
+                const struct = [
+                    0x01,
+                    [0x02, 0x03],
+                    [0x04, 0x05, 0x06, 0x07],
+                ];
+                const expected = hexToBuffer('01 02_03 0400_04_05_06_07');
+
+                const result = cStruct.make(struct);
+                expect(result.buffer).toEqual(expected);
+                expect(result.offset).toBe(9);
+                expect(result.size).toBe(9);
             });
         });
 

--- a/tests/model-parser.test.ts
+++ b/tests/model-parser.test.ts
@@ -78,7 +78,7 @@ describe('ModelParser', () => {
             });
 
             it('should parse a simple type 8', () => {
-                const types = ModelParser.parseTypes(`{Octave:{b:[3/f],v:[3/f]}}`);
+                const types = ModelParser.parseTypes(`{Octave:{b:[f/3],v:[f/3]}}`);
                 const expected = JSON.stringify({Octave: {b: ['f', 'f', 'f'], v: ['f', 'f', 'f']}});
                 expect(types).toEqual(expected);
             });
@@ -136,7 +136,7 @@ describe('ModelParser', () => {
             });
 
             it('should parse a simple type 9', () => {
-                const model = ModelParser.parseModel({a: '[2/u8]'});
+                const model = ModelParser.parseModel({a: '[u8/2]'});
                 const expected = JSON.stringify({a: ['u8', 'u8']});
                 expect(model).toEqual(expected);
             });
@@ -172,7 +172,7 @@ describe('ModelParser', () => {
             });
 
             it('should parse a user type 15', () => {
-                const model = ModelParser.parseModel('Some', {Some: '[2/u16]'});
+                const model = ModelParser.parseModel('Some', {Some: '[u16/2]'});
                 const expected = JSON.stringify(['u16', 'u16']);
                 expect(model).toEqual(expected);
             });
@@ -249,7 +249,7 @@ describe('ModelParser', () => {
             });
 
             it('should parse a simple type 9', () => {
-                const model = ModelParser.parseModel(`{ a: [2/u8] }`);
+                const model = ModelParser.parseModel(`{ a: [u8/2] }`);
                 const expected = JSON.stringify({a: ['u8', 'u8']});
                 expect(model).toEqual(expected);
             });
@@ -285,7 +285,7 @@ describe('ModelParser', () => {
             });
 
             it('should parse a user type 15', () => {
-                const model = ModelParser.parseModel('Some', `{Some:[2/u16]}`);
+                const model = ModelParser.parseModel('Some', `{Some:[u16/2]}`);
                 const expected = JSON.stringify(['u16', 'u16']);
                 expect(model).toEqual(expected);
             });
@@ -321,7 +321,7 @@ describe('ModelParser', () => {
             });
 
             it('should parse model type 23', () => {
-                const model = ModelParser.parseModel(`[2/Some]`, `{Some: {a:u16,b:u8}}`);
+                const model = ModelParser.parseModel(`[Some/2]`, `{Some: {a:u16,b:u8}}`);
                 const expected = JSON.stringify([{a: 'u16', b: 'u8'}, {a: 'u16', b: 'u8'}]);
                 expect(model).toEqual(expected);
             });
@@ -398,7 +398,7 @@ describe('ModelParser', () => {
             describe('staticArray', () => {
                 it('should make static array', () => {
                     const model = ModelParser.parseModel(`{
-                        a:[3/u16]                   
+                        a:[u16/3]                   
                     }`);
                     const expected = JSON.stringify({
                         a: ['u16', 'u16', 'u16']
@@ -518,7 +518,7 @@ describe('ModelParser', () => {
 
                 it('should replace Sensor 1', () => {
                     const model = ModelParser.parseModel(
-                        `[2/Sensor]`,
+                        `[Sensor/2]`,
                         `{Sensor: {type: u8, value: f, time: u64 }}`
                     );
                     const expected = JSON.stringify(
@@ -529,7 +529,7 @@ describe('ModelParser', () => {
 
                 it('should replace Sensor 2', () => {
                     const model = ModelParser.parseModel(
-                        `{sensors: [2/Sensor]}`,
+                        `{sensors: [Sensor/2]}`,
                         `{Sensor: {type: u8, value: f, time: u64 }}`
                     );
                     const expected = JSON.stringify(
@@ -548,7 +548,7 @@ describe('ModelParser', () => {
             });
 
             it('should parse model 2', () => {
-                const model = ModelParser.parseModel(`{a:[3/u8]}`);
+                const model = ModelParser.parseModel(`{a:[u8/3]}`);
                 const expected = JSON.stringify({a: ['u8', 'u8', 'u8']});
                 expect(model).toEqual(expected);
             });


### PR DESCRIPTION
Refactor
Fix dynamic array,
Fix global array `[]`

Now:
    const model = `[
        i8,         // 1 byte
        i8[2],      // 2 bytes static array
        i8[i16]     // i16 bytes dynamic array
    ]`;
works well.