### PR TITLE
static from function in cstruct-le changed to getCStructLE

### DIFF
--- a/src/cstruct-le.ts
+++ b/src/cstruct-le.ts
@@ -65,7 +65,7 @@ export class CStructLE<T> extends CStruct<T> {
     }
 
     static from<T = any>(from: Class | CStructClassOptions | T): CStructLE<T> {
-        return CStructMetadata.getCStructBE(from);
+        return CStructMetadata.getCStructLE(from);
     }
 
     static fromModelTypes<T = any>(model: Model, types?: Types): CStructLE<T> {


### PR DESCRIPTION
Changed the `from` function to get metadata of `LE` instead of `BE`.
@MrHIDEn Please have a look :)