### PR TITLE
docs: reorganize README into Basic / Advanced / Specialized paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /.vscode/
 /.idea/
 
+# Local notes / scratch files (prefix --): never commit
 /--*/
 --*.*
+
 node_modules/
 lib/
 /out/

--- a/README.md
+++ b/README.md
@@ -856,6 +856,10 @@ Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/
 
 ## Changelog
 
+### What's new in 1.5.5
+* Reorganized README into Basic / Advanced / Specialized paths with TOC and Quick start
+* Added examples for LE, write+offset, `bufN`, and `wstring`; added `examples/README.md` index
+
 ### What's new in 1.5
 * Added support for wstring (UTF-16LE) type. Thanks to [Sorunome](https://github.com/Sorunome).<br>
   For wstring/utf16le trailing character is/must be 16bit zero `'\u0000'`.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ const data = { a: 10, b: -10 };
 const buffer = cStruct.make(data).buffer;
 console.log(buffer.toString('hex'));
 // 000afff6
+
+const result = cStruct.read(buffer);
+console.log(result.struct);
+// { a: 10, b: -10 }
 ```
 
 ## Concepts

--- a/README.md
+++ b/README.md
@@ -1,7 +1,23 @@
 # @mrhiden/cstruct
-- *'C like structures'* - TypeScript library
+*'C like structures'* — TypeScript library for packing and unpacking binary data (`Buffer` ⇔ Object/Array).
 
-### Features
+If you only need to pack a plain object into a buffer — **Basic usage** is enough. Classes, decorators, PLC aliases, and C-struct parsing are optional paths below.
+
+## Table of contents
+- [Features](#features)
+- [Install](#install)
+- [Quick start](#quick-start)
+- [Concepts](#concepts)
+- [Basic usage](#basic-usage-objects--strings)
+- [Advanced usage](#advanced-usage-classes--decorators)
+- [Specialized](#specialized-plc-c-struct-json)
+- [Data types reference](#data-types-reference)
+- [More examples](#more-examples)
+- [Changelog](#changelog)
+- [TODO](#todo)
+- [Contact](#contact)
+
+## Features
 * Read/make/write buffer, **Buffer <=> Object/Array**
 * Pack / unpack, compress / decompress data to minimize size.
 * Convert buffer of **struct/array** to TypeScript **object/array** and back
@@ -11,20 +27,693 @@
 * Big endian - BE
 * TypeScript's decorators for classes and properties
 
-### Whats new in 1.4 ?
-* Added predefined types
-* Added predefined aliases
-* Fixed issue in one function where we use endian BE -> LE
-* Added more tests to cover that issue and predefined types
+## Install
+```bash
+npm i @mrhiden/cstruct
+```
 
-### Whats new in 1.5 ?
-* Added support for wstring (UTF-16LE) type. Thanks to [Sorunome](https://github.com/Sorunome).<br>
-  For wstring/utf16le trailing character is/must be 16bit zero '\u0000'.<br>
+## Quick start
 
-### Install
-`npm i @mrhiden/cstruct`
+Precompile a model once, then `make` and `read` as many times as you need:
 
-### Data types, Atom types and aliases
+```javascript
+const { CStructBE, AtomTypes } = require('@mrhiden/cstruct');
+const { U16, I16 } = AtomTypes; // or use 'u16', 'i16' as strings
+
+const model = { a: U16, b: I16 }; // = { a: 'u16', b: 'i16' }
+const cStruct = CStructBE.fromModelTypes(model);
+
+const data = { a: 10, b: -10 };
+const buffer = cStruct.make(data).buffer;
+console.log(buffer.toString('hex'));
+// 000afff6
+
+const result = cStruct.read(buffer);
+console.log(result.struct);
+// { a: 10, b: -10 }
+```
+
+Same cycle in TypeScript with string atom types:
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = { a: 'u16', b: 'i16' };
+const cStruct = CStructBE.fromModelTypes(model);
+
+const data = { a: 10, b: -10 };
+const buffer = cStruct.make(data).buffer;
+console.log(buffer.toString('hex'));
+// 000afff6
+```
+
+## Concepts
+
+The main idea: create a model of your data structure, precompile it into a `CStructBE` or `CStructLE` object, then use that object to read from and write to buffers.
+
+| Class | Endianness |
+|-------|------------|
+| `CStructBE` | Big Endian |
+| `CStructLE` | Little Endian |
+
+Both classes share the same methods and functionality.
+
+- **Dynamic API** — Object/Array/String model and types (`fromModelTypes`)
+- **Static API** — TypeScript decorators on classes (`@CStructClass`, `@CStructProperty`)
+
+**MAKE** — creates a new buffer from data:<br>
+`make(struct: T): CStructWriteResult` → `{ buffer, offset, size }`
+
+**WRITE** — writes into an existing buffer (optional start offset):<br>
+`write(buffer: Buffer, struct: T, offset?: number): CStructWriteResult`
+
+**READ** — reads from an existing buffer (optional start offset):<br>
+`read<T>(buffer: Buffer, offset?: number): CStructReadResult<T>` → `{ struct, offset, size }`
+
+**OFFSET** — pin read/write to any position in the buffer so you can split frames into parts.
+
+**DECORATORS** — `@CStructClass` defines model/types for a class; `@CStructProperty` defines a property type.<br>
+When `@CStructClass` is used with `{ model: ... }` it can override `@CStructProperty` decorators.
+
+---
+
+## Basic usage (objects & strings)
+
+Start here for plain models. No classes or decorators required.
+
+### Nested types and AtomTypes
+
+```javascript
+const { CStructBE, AtomTypes } = require('@mrhiden/cstruct');
+const { U16, I16, STRING } = AtomTypes;
+
+const types = {
+    Sensor: { id: U16, value: I16 },
+};
+const model = {
+    iotName: STRING(0), // 's0'
+    sensors: 'Sensor[2]',
+};
+const cStruct = CStructBE.fromModelTypes(model, types);
+
+const data = {
+    iotName: 'iot-1',
+    sensors: [
+        { id: 1, value: -10 },
+        { id: 2, value: -20 },
+    ],
+};
+const buffer = cStruct.make(data).buffer;
+console.log(buffer.toString('hex'));
+// 696f742d31000001fff60002ffec
+
+const result = cStruct.read(buffer);
+console.log(result.struct);
+// { iotName: 'iot-1', sensors: [ { id: 1, value: -10 }, { id: 2, value: -20 } ] }
+```
+
+### Make and read with nested fields
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const cStruct = CStructBE.fromModelTypes({ error: { code: 'u16', message: 's20' } });
+
+const { buffer, offset, size } = cStruct.make({ error: { code: 10, message: 'xyz' } });
+
+console.log(buffer.toString('hex'));
+// 000a78797a0000000000000000000000000000000000
+console.log(offset); // 22
+console.log(size);   // 22
+```
+
+```typescript
+import { CStructBE, hexToBuffer } from '@mrhiden/cstruct';
+
+const buffer = hexToBuffer('000F 6162630000_0000000000_0000000000');
+const cStruct = CStructBE.fromModelTypes({ error: { code: 'u16', message: 's20' } });
+
+const { struct, offset, size } = cStruct.read(buffer);
+console.log(struct);
+// { error: { code: 15, message: 'abc' } }
+console.log(offset); // 17
+console.log(size);   // 17
+```
+
+### Named types (IoT-style)
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const types = {
+  Sensor: {
+    id: 'u32',
+    type: 'u8',
+    value: 'd',
+    timestamp: 'u64',
+  }
+};
+const iotModel = {
+  iotName: 's20',
+  sensor: 'Sensor',
+};
+
+const sender = CStructBE.fromModelTypes(iotModel, types);
+const senderData = {
+  iotName: 'IOT-1',
+  sensor: {
+    id: 123456789,
+    type: 0x01,
+    value: 123.456,
+    timestamp: 1677277903685n,
+  }
+};
+const { buffer: senderFrame } = sender.make(senderData);
+
+const receiver = CStructBE.fromModelTypes(iotModel, types);
+const { struct: receiverData } = receiver.read(senderFrame);
+console.log(receiverData);
+```
+
+### String-based model and types
+
+Model and types can be strings (or mixed with objects). Comments are allowed in string forms.
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const cStruct = CStructBE.fromModelTypes(
+  `{errors: [Error, Error]}`,
+  `{Error: {code: u16, message: s10}}`
+);
+
+const { buffer, offset, size } = cStruct.make({
+    errors: [
+        { code: 0x12, message: 'message1' },
+        { code: 0x34, message: 'message2' },
+    ]
+});
+
+console.log(buffer.toString('hex'));
+// 00126d65737361676531000000346d657373616765320000
+console.log(offset); // 24
+console.log(size);   // 24
+```
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+// Mixed approach
+const cStruct = CStructBE.fromModelTypes(
+  { errors: `[Error, Error]` },
+  { Error: `{code: u16, message: s10}` }
+);
+```
+
+### Dynamic length
+
+Length can come from another integer field (`u16`, `i16`, …).
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = { ab: "Ab[i16]" };
+const types = { Ab: { a: 'i8', b: 'i8' } };
+const cStruct = CStructBE.fromModelTypes(model, types);
+
+console.log(cStruct.modelClone);
+// { 'ab.i16': { a: 'i8', b: 'i8' } }
+
+const data = {
+    ab: [
+        { a: '-1', b: '+1' },
+        { a: '-2', b: '+2' },
+    ]
+};
+const { buffer } = cStruct.make(data);
+console.log(buffer.toString('hex'));
+// 0002ff01fe02
+
+const { struct: extractedData } = cStruct.read(buffer);
+console.log(extractedData);
+// { ab: [ { a: -1, b: 1 }, { a: -2, b: 2 } ] }
+```
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = {
+    txt1: "s[i16]",
+    txt2: "string[i16]",
+};
+const cStruct = CStructBE.fromModelTypes(model);
+
+const data = { txt1: "ABCDE", txt2: "AB" };
+const { buffer } = cStruct.make(data);
+console.log(buffer.toString('hex'));
+// 0005414243444500024142
+
+const { struct: extractedData } = cStruct.read(buffer);
+console.log(extractedData);
+// { txt1: 'ABCDE', txt2: 'AB' }
+```
+
+### Trailing zero (`s[0]`, `j[0]`, …)
+
+For `"string"`, `"wstring"` and `"json"` types you can use trailing zero: data is written at full unknown length and terminated with `'\0'` (for wstring: 16-bit `'\u0000'`). That lets you read without knowing the length up front. Buffers cannot use this trick — they may contain zeros anywhere.
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = {
+    any1: 'j[0]', // or 'json[0]' / 'any[0]'
+    any2: 's[0]', // or 'string[0]'
+};
+const cStruct = CStructBE.fromModelTypes(model);
+
+const data = { any1: [1, 2, 3], any2: 'abc' };
+const buffer = cStruct.make(data).buffer;
+console.log(buffer.toString('hex'));
+// 5b312c322c335d0061626300
+
+const extractedData = cStruct.read(buffer).struct;
+console.log(extractedData);
+// { any1: [ 1, 2, 3 ], any2: 'abc' }
+```
+
+---
+
+## Advanced usage (classes & decorators)
+
+Use this path when you want typed classes and decorator metadata.
+
+**Must enable in `tsconfig.json` or `jsconfig.json`:**
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
+}
+```
+
+Also see [`/examples/decorators.ts`](https://github.com/MrHIDEn/cstruct/tree/main/examples/decorators.ts).
+
+### Property decorators — make / read
+
+```typescript
+import { CStructBE, CStructProperty } from '@mrhiden/cstruct';
+
+class MyClass {
+    @CStructProperty({ type: 'u8' })
+    public propertyA: number;
+
+    @CStructProperty({ type: 'i8' })
+    public propertyB: number;
+}
+
+const myClass = new MyClass();
+myClass.propertyA = 10;
+myClass.propertyB = -10;
+
+const bufferMake = CStructBE.make(myClass).buffer;
+console.log(bufferMake.toString('hex'));
+// 0af6
+
+const buffer = Buffer.from('0af6', 'hex');
+const readBack = CStructBE.read(MyClass, buffer).struct;
+console.log(readBack);
+// MyClass { propertyA: 10, propertyB: -10 }
+console.log(readBack instanceof MyClass); // true
+```
+
+### Class model via `@CStructClass`
+
+```typescript
+import { CStructBE, CStructClass } from '@mrhiden/cstruct';
+
+@CStructClass({
+    model: {
+        propertyA: 'u8',
+        propertyB: 'i8',
+    }
+})
+class MyClass {
+    public propertyA: number;
+    public propertyB: number;
+}
+
+const buffer = Buffer.from('0af6', 'hex');
+const myClass = CStructBE.read(MyClass, buffer).struct;
+console.log(myClass);
+// MyClass { propertyA: 10, propertyB: -10 }
+```
+
+### Offset + string model/types in decorator
+
+```typescript
+import { CStructBE, CStructClass } from '@mrhiden/cstruct';
+
+@CStructClass({
+    model: `{propertyA: U8, propertyB: I8}`,
+    types: '{U8: uint8, I8: int8}',
+})
+class MyClass {
+    public propertyA: number;
+    public propertyB: number;
+}
+
+const buffer = Buffer.from('77770af6', 'hex');
+const myClass = CStructBE.read(MyClass, buffer, 2).struct;
+console.log(myClass);
+// MyClass { propertyA: 10, propertyB: -10 }
+```
+
+### `CStructBE.from` with class or options
+
+```typescript
+import { CStructBE, CStructClass } from '@mrhiden/cstruct';
+
+class MyClass {
+    public propertyA: number;
+    public propertyB: number;
+}
+
+const myClass = new MyClass();
+myClass.propertyA = 10;
+myClass.propertyB = -10;
+
+const cStruct = CStructBE.from({
+    model: `{propertyA: U16, propertyB: I16}`,
+    types: '{U16: uint16, I16: int16}',
+});
+console.log(cStruct.make(myClass).buffer.toString('hex'));
+// 000afff6
+```
+
+```typescript
+import { CStructBE, CStructClass } from '@mrhiden/cstruct';
+
+@CStructClass({
+    model: `{propertyA: U16, propertyB: I16}`,
+    types: '{U16: uint16, I16: int16}',
+})
+class MyClass {
+    public propertyA: number;
+    public propertyB: number;
+}
+
+const myClass = new MyClass();
+myClass.propertyA = 10;
+myClass.propertyB = -10;
+
+const cStruct = CStructBE.from(MyClass);
+console.log(cStruct.make(myClass).buffer.toString('hex'));
+// 000afff6
+```
+
+### Nested typed property (`CStructModelProperty`)
+
+```typescript
+import { CStructBE, CStructClass, CStructModelProperty } from '@mrhiden/cstruct';
+
+class MyClass {
+    public a: number;
+    public b: number;
+}
+
+@CStructClass({
+    types: { MyClass: { a: 'u16', b: 'i16' } }
+})
+class MyData {
+    @CStructModelProperty('MyClass')
+    public myClass: MyClass;
+}
+
+const myData = new MyData();
+myData.myClass = new MyClass();
+myData.myClass.a = 10;
+myData.myClass.b = -10;
+
+const bufferMake = CStructBE.make(myData).buffer;
+console.log(bufferMake.toString('hex'));
+// 000afff6
+
+const myDataRead = new MyData();
+myDataRead.myClass = new MyClass();
+CStructBE.read(myDataRead, bufferMake);
+console.log(myDataRead);
+// MyData { myClass: MyClass { a: 10, b: -10 } }
+
+const bufferWrite = Buffer.alloc(4);
+CStructBE.write(myData, bufferWrite);
+console.log(bufferWrite.toString('hex'));
+// 000afff6
+```
+
+---
+
+## Specialized (PLC, C-struct, JSON)
+
+Niche and longer examples. Expand only what you need.
+
+<details>
+<summary><strong>PLC aliases</strong> (<code>BYTE</code>, <code>WORD</code>, <code>BOOL</code>, …)</summary>
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = { b: 'BYTE', w: 'WORD', f: 'BOOL' };
+const cStruct = CStructBE.fromModelTypes(model);
+
+const struct = { b: 0x12, w: 0x3456, f: true };
+const { buffer } = cStruct.make(struct);
+console.log(buffer.toString('hex'));
+// 12345601
+
+const { struct: extractedData } = cStruct.read(buffer);
+console.log(extractedData);
+// { b: 18, w: 13398, f: true }
+```
+
+</details>
+
+<details>
+<summary><strong>C-kind fields</strong> (<code>{u8 a,b;}</code>)</summary>
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = `{u8 a,b;}`;
+const cStruct = CStructBE.fromModelTypes(model);
+
+const makeStruct = { a: 1, b: 2 };
+const { buffer: structBuffer } = cStruct.make(makeStruct);
+console.log(structBuffer.toString('hex'));
+// 0102
+
+const { struct: readStruct } = cStruct.read(structBuffer);
+console.log(readStruct);
+// { a: 1, b: 2 }
+```
+
+</details>
+
+<details>
+<summary><strong>C-kind struct / typedef</strong> (comments allowed)</summary>
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = { xyzs: "Xyx[2]" };
+const types = `{
+    typedef struct {
+        uint8_t x;
+        uint8_t y;
+        uint8_t z;
+    } Xyx;
+}`;
+
+const cStruct = CStructBE.fromModelTypes(model, types);
+const data = {
+    xyzs: [
+        { x: 1, y: 2, z: 3 },
+        { x: 4, y: 5, z: 6 },
+    ]
+};
+const { buffer: makeBuffer } = cStruct.make(data);
+console.log(makeBuffer.toString('hex'));
+// 010203040506
+
+const { struct: readStruct } = cStruct.read(makeBuffer);
+console.log(readStruct);
+// { xyzs: [ { x: 1, y: 2, z: 3 }, { x: 4, y: 5, z: 6 } ] }
+```
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const types = `{
+    // 1st approach
+    typedef struct {
+        u8 x,y,z;
+    } Xyz;
+
+    // 2nd approach
+    struct Ab {
+        i8 x,y;
+    };
+}`;
+const model = `{
+    ab: Ab,
+    xyz: Xyz,
+}`;
+
+const cStruct = CStructBE.fromModelTypes(model, types);
+const data = {
+    ab: { x: -2, y: -1 },
+    xyz: { x: 0, y: 1, z: 2 }
+};
+const { buffer: makeBuffer } = cStruct.make(data);
+console.log(makeBuffer.toString('hex'));
+// feff000102
+```
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const model = `[
+    i8,         // 1 byte
+    i8[2],      // 2 bytes static array
+    i8[i16]     // dynamic array
+]`;
+
+const cStruct = CStructBE.fromModelTypes(model);
+console.log(cStruct.jsonModel);
+// ["i8","i8.2","i8.i16"]
+
+const data = [0x01, [0x02, 0x03], [0x04, 0x05, 0x06, 0x07]];
+const { buffer } = cStruct.make(data);
+console.log(buffer.toString('hex'));
+// 010203000404050607
+
+const { struct: extractedData } = cStruct.read(buffer);
+console.log(extractedData);
+// [ 1, [ 2, 3 ], [ 4, 5, 6, 7 ] ]
+```
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+class Undecorated {
+    a: number;
+    b: number;
+}
+const undecorated = new Undecorated();
+undecorated.a = -1;
+undecorated.b = -2;
+
+const undecoratedStruct = CStructBE.from({
+    model: '{a:float,b:double}',
+});
+const undecoratedBuffer = undecoratedStruct.make(undecorated).buffer;
+console.log(undecoratedBuffer.toString('hex'));
+// bf800000c000000000000000
+```
+
+</details>
+
+<details>
+<summary><strong>JSON mode</strong> (<code>j</code> / <code>json</code> / <code>any</code>)</summary>
+
+```typescript
+import { CStructBE, CStructClass } from '@mrhiden/cstruct';
+
+@CStructClass({
+    model: {
+        any1: 'j[i8]',
+        any2: 'json[i8]',
+        any3: 'any[i8]',
+    }
+})
+class MyClass {
+    any1: any;
+    any2: any;
+    any3: any;
+}
+
+const myClass = new MyClass();
+myClass.any1 = { a: 1 };
+myClass.any2 = { b: "B" };
+myClass.any3 = [1, 3, 5];
+
+const buffer = CStructBE.make(myClass).buffer;
+console.log(buffer.toString('hex'));
+// 077b2261223a317d097b2262223a2242227d075b312c332c355d
+
+const myClass2 = CStructBE.read(MyClass, buffer).struct;
+console.log(myClass2);
+// MyClass { any1: { a: 1 }, any2: { b: 'B' }, any3: [ 1, 3, 5 ] }
+```
+
+</details>
+
+<details>
+<summary><strong>Larger realistic example</strong> (file of geo points)</summary>
+
+```typescript
+import { CStructBE, CStructClass, CStructProperty } from '@mrhiden/cstruct';
+import * as fs from "fs";
+
+interface GeoAltitude {
+    lat: number;
+    long: number;
+    alt: number;
+}
+
+@CStructClass({
+    types: `{ GeoAltitude: { lat:double, long:double, alt:double }}`
+})
+class GeoAltitudesFile {
+    @CStructProperty({ type: 'string30' })
+    public fileName: string = 'GeoAltitudesFile v1.0';
+
+    @CStructProperty({ type: 'GeoAltitude[i32]' })
+    public geoAltitudes: GeoAltitude[] = [];
+}
+
+(async () => {
+    const geoAltitudesFile = new GeoAltitudesFile();
+    for (let i = 0; i < 1e6; i++) {
+        const randomLat = Math.random() * (90 - -90) + -90;
+        const randomLong = Math.random() * (180 - -180) + -180;
+        const randomAlt = 6.4e6 * Math.random() * (8e3 - -4e3) + -4e3;
+        geoAltitudesFile.geoAltitudes.push({
+            lat: randomLat,
+            long: randomLong,
+            alt: randomAlt,
+        });
+    }
+
+    const writeFile = CStructBE.make(geoAltitudesFile).buffer;
+    await fs.promises.writeFile('geoAltitudesFile.bin', writeFile);
+
+    const readFile = await fs.promises.readFile('geoAltitudesFile.bin');
+    const readGeoAltitudesFile = CStructBE.read(GeoAltitudesFile, readFile).struct;
+    console.log(readGeoAltitudesFile.fileName);
+    console.log(readGeoAltitudesFile.geoAltitudes.length);
+})();
+```
+
+</details>
+
+---
+
+## Data types reference
+
+<details>
+<summary><strong>Atom types and aliases</strong> (full table)</summary>
+
 | Atom | Type               | Size [B] | Aliases                                     | Notes |
 |------|--------------------|----------|---------------------------------------------|-------|
 | b8   | boolean            | 1        | bool8 bool               BOOL               |       |
@@ -46,822 +735,31 @@
 | bufN | buffer             | N        | buffer                   BUF BUFFER         | N= 1+ |
 | jN   | json               | N        | json any                 J JSON ANY         | N= 0+ |
 
-### Usage
-The main concept is to first create a model of your data structure and then utilize it to read from and write to a buffer.
-1) To achieve this, you can precompile the model and optional types when creating a CStructBE or CStructLE object. 
-2) After this step, you can use the object to efficiently access the buffer and perform read/write operations on your data.
+See also [`doc/DATA_TYPES.md`](https://github.com/MrHIDEn/cstruct/blob/main/doc/DATA_TYPES.md).
 
-For exchanging data between JavaScript and C/C++ you can use the following classes and their methods:
-- CStructBE - Big Endian
-- CStructLE - Little Endian
+</details>
 
-Both classes uses the same methods and have the same functionality.
+## More examples
 
-Dynamic methods uses Object/Array/String model/types to exchange data.<br>
-Static methods are designed to use decorators to define model/types.<br>
+Many runnable examples live in [`/examples`](https://github.com/MrHIDEn/cstruct/tree/main/examples).
 
-**MAKE**<br>
-When using `make` method it returns `{ buffer, offset, size }` object.<br>
-`make(struct: T): CStructWriteResult;`<br>
+## Changelog
 
-**WRITE**<br>
-When using `write` method it returns `{ buffer, offset, size }` object.<br>
-`write(buffer: Buffer, struct: T, offset?: number): CStructWriteResult;`<br>
-Write is different from make because it uses existing buffer and writes data to it.<br>
-Also write allows to pass `offset` to pin start point from any offset in the buffer.<br>
+### What's new in 1.5
+* Added support for wstring (UTF-16LE) type. Thanks to [Sorunome](https://github.com/Sorunome).<br>
+  For wstring/utf16le trailing character is/must be 16bit zero `'\u0000'`.
 
-**READ**<br>
-When using `read` method it returns `{ struct, offset, size }` object.<br>
-`read<T>(buffer: Buffer, offset?: number): CStructReadResult<T>;`<br>
-Read uses existing buffer and reads data from it.<br>
-And also read allows to pass `offset` to pin start point from any offset in the buffer.
+### What's new in 1.4
+* Added predefined types
+* Added predefined aliases
+* Fixed issue in one function where we use endian BE → LE
+* Added more tests to cover that issue and predefined types
 
-**OFFSET**<br>
-Offset can be used in different scenario as we want to read/write from/to buffer from any offset.<br>
-Which allows binary parser to split data into different parts and read/write them separately.<br>
+## TODO
 
-**DECORATORS**<br>
-Decorators are used to define model/types for static methods.<br>
-`@CStructClass` - defines model/types for class.<br>
-`@CStructProperty` - defines type for property.<br>
+See [`doc/TODO.md`](https://github.com/MrHIDEn/cstruct/blob/main/doc/TODO.md).
 
-Static `make` creates new instance of provided class and fills it with parsed data.<br>
+## Contact
 
-**NOTE**<br>
-When using `@CStructClass` decorator with `{model: ... }` it can override `@CStructProperty` decorators.<br>
-
-# JavaScript examples
-**Atomic types instead pure string types**<br>
-```javascript
-const {CStructBE,CStructLE, hexToBuffer, AtomTypes} = require('@mrhiden/cstruct');
-const {U16, I16, STRING} = AtomTypes; // You can also use 'u16', 'i16', 'string' / 's' as before
-
-// JavaScript Example 1
-{
-    // Model with two fields.
-    const model = {a: U16, b: I16}; // = {a: 'u16', b: 'i16'};
-    // Create CStruct from model. Precompile.
-    const cStruct = CStructBE.fromModelTypes(model);
-    // Data to transfer. Make buffer from data. Transfer buffer.
-    const data = {a: 10, b: -10};
-    // Buffer made.
-    const buffer = cStruct.make(data).buffer;
-    console.log(buffer.toString('hex'));
-    // 000afff6
-    // {a: 000a, b: fff6}
-
-    // Read buffer. Receive data.
-    const result = cStruct.read(buffer);
-    console.log(result.struct);
-    // { a: 10, b: -10 }
-}
-
-// JavaScript Example 2
-{
-    // Sensor type. ID and value.
-    const types = {
-        Sensor: {id: U16, value: I16}, // Sensor: {id: 'u16', value: 'i16'},
-    }
-    // Model with IOT name and two sensors.
-    const model = {
-        iotName: STRING(0), // iotName: 's0',
-        sensors: 'Sensor[2]',
-    };
-    // Create CStruct from model and types. Precompile.
-    const cStruct = CStructBE.fromModelTypes(model, types);
-    // Data to transfer. Make buffer from data. Transfer buffer.
-    const data = {
-        iotName: 'iot-1',
-        sensors: [
-            {id: 1, value: -10},
-            {id: 2, value: -20}
-        ]
-    };
-    // Buffer made.
-    const buffer = cStruct.make(data).buffer;
-    console.log(buffer.toString('hex'));
-    // 696f742d31000001fff60002ffec
-    // '696f742d31'00 [{0001, fff6}, {0002, ffec}]
-
-    // Read buffer. Receive data.
-    const result = cStruct.read(buffer);
-    console.log(result.struct);
-    // { iotName: 'iot-1', sensors: [ { id: 1, value: -10 }, { id: 2, value: -20 } ] }
-}
-```
-
-# TypeScript examples
-**Make example**<br>
-```typescript
-import { CStructBE, CStructProperty } from '@mrhiden/cstruct';
-
-class MyClass {
-    @CStructProperty({type: 'u8'})
-    public propertyA: number;
-
-    @CStructProperty({type: 'i8'})
-    public propertyB: number;
-}
-
-const myClass = new MyClass();
-myClass.propertyA = 10;
-myClass.propertyB = -10;
-
-const bufferMake = CStructBE.make(myClass).buffer;
-console.log(bufferMake.toString('hex'));
-// 0af6
-// 0a f6
-````
-**Read example**<br>
-```typescript
-import { CStructBE, CStructProperty } from '@mrhiden/cstruct';
-
-class MyClass {
-    @CStructProperty({type: 'u8'})
-    public propertyA: number;
-
-    @CStructProperty({type: 'i8'})
-    public propertyB: number;
-}
-
-const buffer = Buffer.from('0af6', 'hex');
-const myClass = CStructBE.read(MyClass, buffer).struct;
-
-console.log(myClass);
-// MyClass { propertyA: 10, propertyB: -10 }
-console.log(myClass instanceof MyClass);
-// true
-````
-**CStructClass example**<br>
-```typescript
-import { CStructBE, CStructClass } from '@mrhiden/cstruct';
-
-@CStructClass({
-    model: {
-        propertyA: 'u8',
-        propertyB: 'i8',
-    }
-})
-class MyClass {
-    public propertyA: number;
-    public propertyB: number;
-}
-
-const buffer = Buffer.from('0af6', 'hex');
-const myClass = CStructBE.read(MyClass, buffer).struct;
-
-console.log(myClass);
-// MyClass { propertyA: 10, propertyB: -10 }
-console.log(myClass instanceof MyClass);
-// true
-```
-**Read example with offset, and model and types described as string in CStructClass decorator**<br>
-```typescript
-import { CStructBE, CStructClass } from '@mrhiden/cstruct';
-
-@CStructClass({
-    model: `{propertyA: U8, propertyB: I8}`,
-    types: '{U8: uint8, I8: int8}',
-})
-class MyClass {
-    public propertyA: number;
-    public propertyB: number;
-}
-
-const buffer = Buffer.from('77770af6', 'hex');
-const myClass = CStructBE.read(MyClass, buffer, 2).struct;
-
-console.log(myClass);
-// MyClass { propertyA: 10, propertyB: -10 }
-console.log(myClass instanceof MyClass);
-// true
-```
-Off course `types: '{U8: uint8, I8: int8}'` shows only some idea how to use types.<br>
-Types can be much more complex.<br>
-
-### [Many examples are in this folder '/examples'](https://github.com/MrHIDEn/cstruct/tree/main/examples)
-
-### Basic examples
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Make BE buffer from struct based on model
-const model = { a: 'u16', b: 'i16' };
-const cStruct = CStructBE.fromModelTypes(model);
-
-const data = { a: 10, b: -10 };
-const buffer = cStruct.make(data).buffer;
-
-console.log(buffer.toString('hex'));
-// 000afff6
-// 000a fff6
-````
-
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Make BE buffer from struct based on model
-const cStruct = CStructBE.fromModelTypes({ error: {code: 'u16', message: 's20'} });
-
-const { buffer, offset, size } = cStruct.make({ error: { code: 10, message: 'xyz' } });
-
-console.log(buffer.toString('hex'));
-// 000a78797a0000000000000000000000000000000000
-console.log(offset);
-// 22
-console.log(size);
-// 22
-````
-
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Read BE buffer to struct based on model
-const buffer = hexToBuffer('000F 6162630000_0000000000_0000000000');
-console.log(buffer.toString('hex'));
-// 000f616263000000000000000000000000
-
-const cStruct = CStructBE.fromModelTypes({ error: {code: 'u16', message: 's20'} });
-
-const struct = cStruct.read(buffer).struct;
-
-console.log(struct);
-// { error: { code: 15, message: 'abc' } }
-````
-
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Read BE buffer to struct based on model
-const buffer = hexToBuffer('000F 6162630000_0000000000_0000000000');
-console.log(buffer.toString('hex'));
-// 000f616263000000000000000000000000
-
-const cStruct = CStructBE.fromModelTypes({ error: {code: 'u16', message: 's20'} });
-
-const { struct, offset, size } = cStruct.read(buffer);
-
-console.log(struct);
-// { error: { code: 15, message: 'abc' } }
-console.log(offset);
-// 17
-console.log(size);
-// 17
-````
-
-### Examples with classes
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-class MyClass {
-    public propertyA: number;
-    public propertyB: number;
-}
-
-const myClass = new MyClass();
-myClass.propertyA = 10;
-myClass.propertyB = -10;
-
-const cStruct = CStructBE.from({
-    model: `{propertyA: U16, propertyB: I16}`,
-    types: '{U16: uint16, I16: int16}',
-});
-const make = cStruct.make(myClass);
-console.log(make.buffer.toString('hex'));
-// 000afff6
-// 000a fff6
-```
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-@CStructClass({
-    model: `{propertyA: U16, propertyB: I16}`,
-    types: '{U16: uint16, I16: int16}',
-})
-class MyClass {
-    public propertyA: number;
-    public propertyB: number;
-}
-
-const myClass = new MyClass();
-myClass.propertyA = 10;
-myClass.propertyB = -10;
-
-const cStruct = CStructBE.from(MyClass);
-const make = cStruct.make(myClass);
-console.log(make.buffer.toString('hex'));
-// 000afff6
-// 000a fff6
-```
-
-### Examples with types
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Model and Types for Sender & Receiver
-const types = {
-  Sensor: {
-    id: 'u32',
-    type: 'u8',
-    value: 'd',
-    timestamp: 'u64',
-  }
-};
-const iotModel = {
-  iotName: 's20',
-  sensor: 'Sensor',
-};
-
-// IOT Sender
-const sender = CStructBE.fromModelTypes(iotModel, types);
-const senderData = {
-  iotName: 'IOT-1',
-  sensor: {
-    id: 123456789,
-    type: 0x01,
-    value: 123.456,
-    timestamp: 1677277903685n,
-  }
-};
-const { buffer: senderFrame } = sender.make(senderData);
-
-// Transmitting frame
-console.log(senderFrame.toString('hex'));
-
-// IOT Receiver
-const receiver = CStructBE.fromModelTypes(iotModel, types);
-const { struct: receiverData } = receiver.read(senderFrame);
-console.log(receiverData);
-// {
-//   iotName: 'IOT-1',
-//   sensor: {
-//      id: 123456789,
-//      type: 1,
-//      value: 123.456,
-//      timestamp: 1677277903685
-//    }
-//  }
-````
-
-### String based examples. Model and Types are strings but you can mix approach
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Make buffer from struct based on model and types
-const cStruct = CStructBE.fromModelTypes(`{errors: [Error, Error]}`, `{Error: {code: u16, message: s10}}`);
-
-const {buffer, offset, size} = cStruct.make({
-    errors: [
-        {code: 0x12, message: 'message1'},
-        {code: 0x34, message: 'message2'},
-    ]
-});
-
-console.log(buffer.toString('hex'));
-// 00126d65737361676531000000346d657373616765320000
-console.log(offset);
-// 24
-console.log(size);
-// 24
-```
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Mixed approach for model and types
-const cStruct = CStructBE.fromModelTypes({errors: `[Error, Error]`}, {Error: `{code: u16, message: s10}`});
-
-const {buffer, offset, size} = cStruct.make({
-    errors: [
-        {code: 0x12, message: 'message1'},
-        {code: 0x34, message: 'message2'},
-    ]
-});
-
-console.log(buffer.toString('hex'));
-// 00126d65737361676531000000346d657373616765320000
-console.log(offset);
-// 24
-console.log(size);
-// 24
-```
-
-### C-kind data fields
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// C-kind fields {u8 a,b;} into {a:u8,b:u8}
-const model = `{u8 a,b;}`;
-const cStruct = CStructBE.fromModelTypes(model);
-
-const makeStruct = { a: 1, b: 2 };
-const { buffer: structBuffer } = cStruct.make(
-    makeStruct
-);
-console.log(structBuffer.toString('hex'));
-// 0102
-
-const { struct: readStruct } = cStruct.read(structBuffer);
-console.log(readStruct);
-// { a: 1, b: 2 }
-```
-
-### Dynamic length
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Dynamic (length) array with types
-const model = {
-    ab: "Ab[i16]",
-};
-
-const types = {
-    Ab: {a: 'i8', b: 'i8'}
-};
-
-const cStruct = CStructBE.fromModelTypes(model, types);
-
-console.log(cStruct.modelClone);
-// { 'ab.i16': { a: 'i8', b: 'i8' } }
-
-const data = {
-    ab: [
-        {a: '-1', b: '+1'},
-        {a: '-2', b: '+2'},
-    ]
-};
-const {buffer} = cStruct.make(data);
-
-console.log(buffer.toString('hex'));
-// 0002ff01fe02
-
-const {struct: extractedData} = cStruct.read(buffer);
-console.log(extractedData);
-// { ab: [ { a: -1, b: 1 }, { a: -2, b: 2 } ] }
-```
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Dynamic (length) string
-const model = {
-    txt1: "s[i16]",
-    txt2: "string[i16]",
-};
-
-const cStruct = CStructBE.fromModelTypes(model);
-
-console.log(cStruct.modelClone);
-// { 'txt1.i16': 's', 'txt2.i16': 's' }
-
-const data = {
-    txt1: "ABCDE",
-    txt2: "AB"
-};
-const {buffer} = cStruct.make(data);
-
-console.log(buffer.toString('hex'));
-// 0005414243444500024142
-// 0005_4142434445 0002_4142
-
-const {struct: extractedData} = cStruct.read(buffer);
-console.log(extractedData);
-// { txt1: 'ABCDE', txt2: 'AB' }
-```
-
-### PLC example
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-const model = {b: 'BYTE', w: 'WORD', f: 'BOOL'};
-
-const cStruct = CStructBE.fromModelTypes(model);
-
-console.log(cStruct.modelClone);
-// { b: 'BYTE', w: 'WORD', f: 'BOOL' }
-
-const struct = {b: 0x12, w: 0x3456, f: true};
-const {buffer} = cStruct.make(struct);
-
-console.log(buffer.toString('hex'));
-// 12345601
-// 12 3456 01
-
-const {struct: extractedData} = cStruct.read(buffer);
-console.log(extractedData);
-// { b: 18, w: 13398, f: true }
-// { b: 0x12, w: 0x3456, f: true }
-```
-
-### C-kind struct
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// C struct types
-const model = {
-    xyzs: "Xyx[2]",
-};
-const types = `{
-    typedef struct {
-        uint8_t x;
-        uint8_t y;
-        uint8_t z;
-    } Xyx;
-}`;
-
-const cStruct = CStructBE.fromModelTypes(model, types);
-
-const data = {
-    xyzs: [
-        {x: 1, y: 2, z: 3},
-        {x: 4, y: 5, z: 6},
-    ]
-};
-const {buffer: makeBuffer} = cStruct.make(data);
-
-console.log(makeBuffer.toString('hex'));
-// 010203040506
-
-const {struct: readStruct} = cStruct.read(makeBuffer);
-console.log(readStruct);
-// { xyzs: [ { x: 1, y: 2, z: 3 }, { x: 4, y: 5, z: 6 } ] }
-```
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// C struct types
-const types = `{
-    // 1st approach
-    typedef struct {
-        u8 x,y,z;
-    } Xyz;
-    
-    // 2nd approach
-    struct Ab {
-        i8 x,y;
-    };
-    
-    // As you noticed, comments are allowed
-}`;
-const model = `{
-    ab: Ab,
-    xyz: Xyz,
-    
-    // As you noticed, comments are allowed
-}`;
-
-const cStruct = CStructBE.fromModelTypes(model, types);
-
-const data = {
-    ab: { x: -2, y: -1 },
-    xyz: { x: 0, y: 1, z: 2 }
-};
-const {buffer: makeBuffer} = cStruct.make(data);
-
-console.log(makeBuffer.toString('hex'));
-// feff000102
-
-const {struct: readStruct} = cStruct.read(makeBuffer);
-console.log(readStruct);
-// { ab: { x: -2, y: -1 }, xyz: { x: 0, y: 1, z: 2 } }
-```
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-// Value, static array, dynamic array
-const model = `[
-    i8,         // 1 byte
-    i8[2],      // 2 bytes static array
-    i8[i16]     // i16 bytes dynamic array
-]`;
-
-const cStruct = CStructBE.fromModelTypes(model);
-
-console.log(cStruct.jsonModel);
-// ["i8","i8.2","i8.i16"]
-console.log(cStruct.modelClone);
-// [ 'i8', 'i8.2', 'i8.i16' ]
-
-const data = [
-    0x01,
-    [0x02, 0x03],
-    [0x04, 0x05, 0x06, 0x07],
-];
-const {buffer} = cStruct.make(data);
-
-console.log(buffer.toString('hex'));
-// 010203000404050607
-// 01 02_03 0004_04_05_06_07
-
-const {struct: extractedData} = cStruct.read(buffer);
-console.log(extractedData);
-// [ 1, [ 2, 3 ], [ 4, 5, 6, 7 ] ]
-```
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-class Undecorated {
-    a: number;
-    b: number;
-}
-const undecorated = new Undecorated();
-undecorated.a = -1;
-undecorated.b = -2;
-
-const undecoratedStruct = CStructBE.from({
-    model: '{a:float,b:double}',
-});
-const undecoratedBuffer = undecoratedStruct.make(undecorated).buffer;
-console.log(undecoratedBuffer.toString('hex'));
-// bf800000c000000000000000
-// bf800000 c000000000000000
-```
-
-### Decorators
-TypeScript's decorators to serialize/deserialize class object to/from binary
-
-**NOTE** Take a look on ['/examples/decorators.ts'](https://github.com/MrHIDEn/cstruct/tree/main/examples/decorators.ts)
-
-**MUST enable in `tsconfig.json` or `jsconfig.json`**
-```json
-{
-  "compilerOptions": {
-    "experimentalDecorators": true
-  }
-}
-```
-
-```typescript
-import { CStructBE, CStructClass, CStructModelProperty } from '@mrhiden/cstruct';
-
-// Decorators - Serialize any class with CStructClass and CStructModelProperty decorator, model and type
-class MyClass {
-    public a: number;
-    public b: number;
-}
-
-@CStructClass({
-    types: {MyClass: {a: 'u16', b: 'i16'}}
-})
-class MyData {
-    @CStructModelProperty('MyClass')
-    public myClass: MyClass;
-}
-
-const myData = new MyData();
-myData.myClass = new MyClass();
-myData.myClass.a = 10;
-myData.myClass.b = -10;
-
-// MAKE
-const bufferMake = CStructBE.make(myData).buffer;
-console.log(bufferMake.toString('hex'));
-// 000afff6
-// 000a fff6
-
-// READ
-const myDataRead = new MyData();
-myDataRead.myClass = new MyClass();
-CStructBE.read(myDataRead, bufferMake);
-console.log(myDataRead);
-// MyData { myClass: MyClass { a: 10, b: -10 } }
-
-// WRITE
-const bufferWrite = Buffer.alloc(4);
-CStructBE.write(myData, bufferWrite);
-console.log(bufferWrite.toString('hex'));
-// 000afff6
-// 000a fff6
-```
-
-### Some more realistic example
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-import * as fs from "fs";
-
-interface GeoAltitude {
-    lat: number;
-    long: number;
-    alt: number;
-}
-
-@CStructClass({
-    types: `{ GeoAltitude: { lat:double, long:double, alt:double }}`
-})
-class GeoAltitudesFile {
-    @CStructProperty({type: 'string30'})
-    public fileName: string = 'GeoAltitudesFile v1.0';
-
-    @CStructProperty({type: 'GeoAltitude[i32]'})
-    public geoAltitudes: GeoAltitude[] = [];
-}
-
-(async () => {
-    // Make random data
-    const geoAltitudesFile = new GeoAltitudesFile();
-    for (let i = 0; i < 1e6; i++) {
-        let randomLat = Math.random() * (90 - -90) + -90;
-        let randomLong = Math.random() * (180 - -180) + -180;
-        let randomAlt = 6.4e6 * Math.random() * (8e3 - -4e3) + -4e3;
-        const geo = {lat: randomLat, long: randomLong, alt: randomAlt};
-        geoAltitudesFile.geoAltitudes.push(geo);
-    }
-    console.log('Write data length,', geoAltitudesFile.geoAltitudes.length);
-
-    // Make buffer
-    console.time('make');
-    const writeFile = CStructBE.make(geoAltitudesFile).buffer;
-    console.timeEnd('make');
-    
-    // Write to file
-    console.log('Write file length,', writeFile.length);
-    await fs.promises.writeFile('geoAltitudesFile.bin', writeFile);
-
-    // Read from file
-    const readFile = await fs.promises.readFile('geoAltitudesFile.bin');
-    console.log('Read file length,', readFile.length);
-
-    // Read data
-    console.time('read');
-    const readGeoAltitudesFile = CStructBE.read(GeoAltitudesFile, readFile).struct;
-    console.timeEnd('read');
-
-    console.log('Read fileName,', readGeoAltitudesFile.fileName);
-    console.log('Read data length,', readGeoAltitudesFile.geoAltitudes.length);
-})();
-```
-
-### JSON mode
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-@CStructClass({
-    model: {
-        any1: 'j[i8]',
-        any2: 'json[i8]',
-        any3: 'any[i8]',
-    }
-})
-class MyClass {
-    any1: any;
-    any2: any;
-    any3: any;
-}
-
-const myClass = new MyClass();
-myClass.any1 = {a: 1};
-myClass.any2 = {b: "B"};
-myClass.any3 = [1, 3, 5];
-
-const buffer = CStructBE.make(myClass).buffer;
-console.log(buffer.toString('hex'));
-// 077b2261223a317d097b2262223a2242227d075b312c332c355d
-// 07_7b2261223a317d 09_7b2262223a2242227d 07_5b312c332c355d
-const myClass2 = CStructBE.read(MyClass, buffer).struct;
-console.log(myClass2);
-// MyClass {
-//   any1: { a: 1 },
-//   any2: { b: 'B' },
-//   any3: [ 1, 3, 5 ]
-// }
-```
-
-### Trailing zero support for "string", "wstring" and "json" types ("s", "string", "ws", "wstring", "j", "json", "any")
-This library has support for trailing zero for "string" and "json" types.<br>
-When you use it "json" and "string" will be written as full unknown length and '\0' will be added at the end.<br>
-That ending zero helps to read data from binary file without knowing the length of the string / json.<br>
-We can not use that trick with buffer as it may contain zeros at any place.<br>
-For wstring/utf16le trailing character is/must be 16bit zero '\u0000'.<br>
-
-```typescript
-import { CStructBE } from '@mrhiden/cstruct';
-
-const model = {
-    any1: 'j[0]', // or 'json[0]' or 'any[0]'
-    any2: 's[0]', // or 'string[0]'
-};
-
-const cStruct = CStructBE.fromModelTypes(model);
-
-const data = {
-    any1: [1, 2, 3],
-    any2: 'abc',
-};
-
-const buffer = cStruct.make(data).buffer;
-console.log(buffer.toString('hex'));
-// 5b312c322c335d0061626300
-// 5b_31_2c_32_2c_33_5d_00 616263_00
-// [  1  ,  2  ,  3  ]  \0 a b c  \0
-
-const extractedData = cStruct.read(buffer).struct;
-console.log(extractedData);
-// { any1: [ 1, 2, 3 ], any2: 'abc' }
-
-console.log(JSON.stringify(data) === JSON.stringify(extractedData));
-// true
-```
-
-### [TODO](https://github.com/MrHIDEn/cstruct/blob/main/doc/TODO.md)
-
-### Contact
 If you have any questions or suggestions, please contact me at<br>
 [mrhiden@outlook.com](mailto:mrhiden@outlook.com)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ If you only need to pack a plain object into a buffer — **Basic usage** is eno
 - [Quick start](#quick-start)
 - [Concepts](#concepts)
 - [Basic usage](#basic-usage-objects--strings)
+  - [Endianness (BE vs LE)](#endianness-be-vs-le)
+  - [Write into an existing buffer](#write-into-an-existing-buffer)
+  - [Binary buffer field (`bufN`)](#binary-buffer-field-bufn)
+  - [Wide string (`wstring` / `wsN`)](#wide-string-wstring--wsn)
 - [Advanced usage](#advanced-usage-classes--decorators)
 - [Specialized](#specialized-plc-c-struct-json)
 - [Data types reference](#data-types-reference)
@@ -71,6 +75,8 @@ console.log(result.struct);
 // { a: 10, b: -10 }
 ```
 
+Use `CStructLE` instead of `CStructBE` when your protocol is little-endian — same API, different byte order (see [Endianness](#endianness-be-vs-le)).
+
 ## Concepts
 
 The main idea: create a model of your data structure, precompile it into a `CStructBE` or `CStructLE` object, then use that object to read from and write to buffers.
@@ -104,6 +110,25 @@ When `@CStructClass` is used with `{ model: ... }` it can override `@CStructProp
 ## Basic usage (objects & strings)
 
 Start here for plain models. No classes or decorators required.
+
+### Endianness (BE vs LE)
+
+Same model and data — only the endian class changes the wire format:
+
+```typescript
+import { CStructBE, CStructLE } from '@mrhiden/cstruct';
+
+const model = { a: 'u16', b: 'i16' };
+const data = { a: 10, b: -10 };
+
+const beHex = CStructBE.fromModelTypes(model).make(data).buffer.toString('hex');
+const leHex = CStructLE.fromModelTypes(model).make(data).buffer.toString('hex');
+
+console.log(beHex); // 000afff6
+console.log(leHex); // 0a00f6ff
+```
+
+See also [`examples/little-endian.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/little-endian.ts).
 
 ### Nested types and AtomTypes
 
@@ -163,6 +188,73 @@ console.log(struct);
 console.log(offset); // 17
 console.log(size);   // 17
 ```
+
+### Write into an existing buffer
+
+`make` allocates a new buffer. `write` patches data into a buffer you already have — useful for frames with headers, footers, or reserved slots.
+
+```typescript
+import { CStructBE, hexToBuffer } from '@mrhiden/cstruct';
+
+const frame = hexToBuffer('111111 22222222222222222222222222222222222222222222 333333');
+const cStruct = CStructBE.fromModelTypes({ error: { code: 'u16', message: 's20' } });
+
+const { buffer, offset, size } = cStruct.write(
+    frame,
+    { error: { code: 0x44, message: 'xyz' } },
+    3 // start writing at byte 3
+);
+
+console.log(buffer.toString('hex'));
+// 111111004478797a00000000000000000000000000000000333333
+console.log(offset); // 25
+console.log(size);   // 22
+```
+
+See also [`examples/write-offset.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/write-offset.ts).
+
+### Binary buffer field (`bufN`)
+
+Use `bufN` (or `buffer`, `BUF`) for raw binary blobs with a fixed size. Values are Node `Buffer` objects.
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+const cStruct = CStructBE.fromModelTypes(`{ cnt: i16, buf: buf10 }`);
+
+const { buffer } = cStruct.make({
+    cnt: 15,
+    buf: Buffer.from('ABCD'),
+});
+
+console.log(buffer.toString('hex'));
+// 000f41424344000000000000
+
+const { struct } = cStruct.read(buffer);
+console.log(struct.buf); // <Buffer 41 42 43 44 00 00 00 00 00 00>
+```
+
+See also [`examples/with-buffer.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/with-buffer.ts).
+
+### Wide string (`wstring` / `wsN`)
+
+`wsN` stores UTF-16LE text. Each character is 2 bytes; fixed `ws5` reserves 5 code units (10 bytes). Trailing zero uses `ws[0]` or `ws0` — terminator is 16-bit `'\u0000'`.
+
+```typescript
+import { CStructLE } from '@mrhiden/cstruct';
+
+const cStruct = CStructLE.fromModelTypes({ label: 'ws5' });
+
+const { buffer } = cStruct.make({ label: 'abc' });
+console.log(buffer.toString('hex'));
+// 61006200630000000000
+
+const { struct } = cStruct.read(buffer);
+console.log(struct);
+// { label: 'abc' }
+```
+
+See also [`examples/wstring.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/wstring.ts).
 
 ### Named types (IoT-style)
 
@@ -745,7 +837,22 @@ See also [`doc/DATA_TYPES.md`](https://github.com/MrHIDEn/cstruct/blob/main/doc/
 
 ## More examples
 
-Many runnable examples live in [`/examples`](https://github.com/MrHIDEn/cstruct/tree/main/examples).
+Runnable scripts live in [`/examples`](https://github.com/MrHIDEn/cstruct/tree/main/examples). Build first (`npm run build`), then `npx ts-node examples/<file>.ts`.
+
+| File | Topic |
+|------|-------|
+| [`simple-model.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/simple-model.ts) | Basic make/read, offset, write |
+| [`little-endian.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/little-endian.ts) | BE vs LE side-by-side |
+| [`write-offset.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/write-offset.ts) | `make` vs `write` with offset |
+| [`with-buffer.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/with-buffer.ts) | `bufN` binary fields |
+| [`wstring.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/wstring.ts) | UTF-16LE wide strings |
+| [`dynamic-model.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/dynamic-model.ts) | Dynamic arrays and strings |
+| [`decorators.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/decorators.ts) | Class decorators |
+| [`c-struct-types.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/c-struct-types.ts) | C `typedef struct` |
+| [`plc.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/plc.ts) | PLC aliases |
+| [`JS-from-model-types.js`](https://github.com/MrHIDEn/cstruct/blob/main/examples/JS-from-model-types.js) | JavaScript (CommonJS) |
+
+Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/examples/README.md).
 
 ## Changelog
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# Examples
+
+Runnable scripts in this folder. Build first (`npm run build`), then run with `npx ts-node examples/<file>.ts`.
+
+| File | Topic |
+|------|-------|
+| [`simple-model.ts`](./simple-model.ts) | Basic make/read, offset, write into existing buffer |
+| [`simple-model-types.ts`](./simple-model-types.ts) | Named types, arrays, `write` |
+| [`string-model.ts`](./string-model.ts) | String-based models, LE vs BE |
+| [`string-model-types.ts`](./string-model-types.ts) | String models + named types |
+| [`little-endian.ts`](./little-endian.ts) | BE vs LE side-by-side |
+| [`write-offset.ts`](./write-offset.ts) | `make` vs `write` with offset |
+| [`with-buffer.ts`](./with-buffer.ts) | `bufN` / binary buffer fields |
+| [`wstring.ts`](./wstring.ts) | `wsN` / UTF-16LE wide strings |
+| [`trailing-zero.ts`](./trailing-zero.ts) | Trailing zero for `s[0]`, `j[0]`, arrays |
+| [`ending-zero.ts`](./ending-zero.ts) | End-zero variants (`s0`, `j0`, `buf0`) |
+| [`dynamic-model.ts`](./dynamic-model.ts) | Dynamic arrays, strings, buffers |
+| [`json-model.ts`](./json-model.ts) | JSON / `any` fields with decorators |
+| [`decorators.ts`](./decorators.ts) | `@CStructClass`, `@CStructProperty` |
+| [`c-struct-types.ts`](./c-struct-types.ts) | C `typedef struct` parsing |
+| [`plc.ts`](./plc.ts) | PLC aliases (`BYTE`, `WORD`, `BOOL`) |
+| [`JS-from-model-types.js`](./JS-from-model-types.js) | JavaScript (CommonJS) usage |
+| [`JS-ending-zero.js`](./JS-ending-zero.js) | JavaScript trailing/end zero |
+
+`npm run sandbox` runs [`sandbox.ts`](./sandbox.ts) for local experiments.

--- a/examples/little-endian.ts
+++ b/examples/little-endian.ts
@@ -1,0 +1,20 @@
+import { CStructBE, CStructLE } from "../src";
+
+{
+    const model = { a: 'u16', b: 'i16' };
+    const data = { a: 10, b: -10 };
+
+    const be = CStructBE.fromModelTypes(model).make(data).buffer;
+    const le = CStructLE.fromModelTypes(model).make(data).buffer;
+
+    console.log('BE:', be.toString('hex'));
+    // 000afff6
+
+    console.log('LE:', le.toString('hex'));
+    // 0a00f6ff
+
+    // Same struct, different byte order — pick the class that matches your protocol
+    console.log(CStructBE.fromModelTypes(model).read(be).struct);
+    console.log(CStructLE.fromModelTypes(model).read(le).struct);
+    // both: { a: 10, b: -10 }
+}

--- a/examples/sandbox.ts
+++ b/examples/sandbox.ts
@@ -1,0 +1,1 @@
+// Local playground — edit this file and run: npm run sandbox

--- a/examples/write-offset.ts
+++ b/examples/write-offset.ts
@@ -1,0 +1,26 @@
+import { CStructBE, hexToBuffer } from "../src";
+
+{
+    // make — allocates a new buffer
+    const cStruct = CStructBE.fromModelTypes({ error: { code: 'u16', message: 's20' } });
+    const { buffer } = cStruct.make({ error: { code: 10, message: 'xyz' } });
+    console.log(buffer.toString('hex'));
+    // 000a78797a0000000000000000000000000000000000
+}
+
+{
+    // write — patch an existing buffer at a chosen offset
+    const frame = hexToBuffer('111111 22222222222222222222222222222222222222222222 333333');
+    const cStruct = CStructBE.fromModelTypes({ error: { code: 'u16', message: 's20' } });
+
+    const { buffer, offset, size } = cStruct.write(
+        frame,
+        { error: { code: 0x44, message: 'xyz' } },
+        3
+    );
+
+    console.log(buffer.toString('hex'));
+    // 111111004478797a00000000000000000000000000000000333333
+    console.log(offset); // 25
+    console.log(size);   // 22
+}

--- a/examples/wstring.ts
+++ b/examples/wstring.ts
@@ -1,0 +1,29 @@
+import { CStructBE, CStructLE } from "../src";
+
+{
+    // Fixed-size wstring (UTF-16LE), 5 code units = 10 bytes
+    const model = { label: 'ws5' };
+    const cStruct = CStructLE.fromModelTypes(model);
+
+    const { buffer } = cStruct.make({ label: 'abc' });
+    console.log(buffer.toString('hex'));
+    // 61006200630000000000
+
+    const { struct } = cStruct.read(buffer);
+    console.log(struct);
+    // { label: 'abc' }
+}
+
+{
+    // Trailing zero wstring — read without knowing length up front
+    const model = { label: 'ws[0]' }; // or 'wstring[0]'
+    const cStruct = CStructBE.fromModelTypes(model);
+
+    const { buffer } = cStruct.make({ label: 'hi' });
+    console.log(buffer.toString('hex'));
+    // 680069000000
+
+    const { struct } = cStruct.read(buffer);
+    console.log(struct);
+    // { label: 'hi' }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrhiden/cstruct",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "MIT",
       "devDependencies": {
         "@mrhiden/cstruct": "1.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "For packing and unpacking bytes (C like structures) in/from Buffer based on Object/Array type for parsing.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Add TOC, Quick start, and an explicit “Basic is enough” path so new readers are not flooded by decorators/PLC/C-struct up front
- Group examples into Basic (objects & strings), Advanced (classes & decorators), and Specialized (PLC, C-struct, JSON); collapse long niche sections and the atom-type table in `<details>`
- Move changelog to the bottom; keep example content intact with clearer hierarchy

## Test plan
- [ ] Skim README on GitHub — TOC links and `<details>` expand correctly
- [ ] Confirm Quick start is visible above the type table / changelog
- [ ] Spot-check that key examples (make/read, decorators, dynamic length, trailing zero) are still present
- [ ] npm page / raw README render looks readable on mobile width


Made with [Cursor](https://cursor.com)