### PR TITLE
Add fromCompiled API for precompiled jsonModel (v1.6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you only need to pack a plain object into a buffer — **Basic usage** is eno
 - [Concepts](#concepts)
 - [Basic usage](#basic-usage-objects--strings)
   - [Endianness (BE vs LE)](#endianness-be-vs-le)
+  - [Precompiled models (`fromCompiled`)](#precompiled-models-fromcompiled)
   - [Write into an existing buffer](#write-into-an-existing-buffer)
   - [Binary buffer field (`bufN`)](#binary-buffer-field-bufn)
   - [Wide string (`wstring` / `wsN`)](#wide-string-wstring--wsn)
@@ -88,7 +89,7 @@ The main idea: create a model of your data structure, precompile it into a `CStr
 
 Both classes share the same methods and functionality.
 
-- **Dynamic API** — Object/Array/String model and types (`fromModelTypes`)
+- **Dynamic API** — Object/Array/String model and types (`fromModelTypes`, `fromCompiled`)
 - **Static API** — TypeScript decorators on classes (`@CStructClass`, `@CStructProperty`)
 
 **MAKE** — creates a new buffer from data:<br>
@@ -129,6 +130,28 @@ console.log(leHex); // 0a00f6ff
 ```
 
 See also [`examples/little-endian.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/little-endian.ts).
+
+### Precompiled models (`fromCompiled`)
+
+Compile a model once (e.g. at build time), save the `jsonModel` string, and load it at runtime without running `ModelParser` again:
+
+```typescript
+import { CStructBE } from '@mrhiden/cstruct';
+
+// Build time: compile and persist jsonModel
+const compiled = CStructBE.fromModelTypes({ a: 'u16', b: 'i16' });
+const jsonModel = compiled.jsonModel; // e.g. save to a file or constant
+
+// Runtime: load precompiled model
+const cStruct = CStructBE.fromCompiled(jsonModel);
+
+const data = { a: 10, b: -10 };
+const buffer = cStruct.make(data).buffer;
+console.log(cStruct.read(buffer).struct);
+// { a: 10, b: -10 }
+```
+
+`fromCompiled` accepts a JSON string or a parsed object/array (the same shape as `jsonModel`). See [`examples/from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts).
 
 ### Nested types and AtomTypes
 
@@ -843,6 +866,7 @@ Runnable scripts live in [`/examples`](https://github.com/MrHIDEn/cstruct/tree/m
 |------|-------|
 | [`simple-model.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/simple-model.ts) | Basic make/read, offset, write |
 | [`little-endian.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/little-endian.ts) | BE vs LE side-by-side |
+| [`from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts) | Precompiled `jsonModel` / `fromCompiled` |
 | [`write-offset.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/write-offset.ts) | `make` vs `write` with offset |
 | [`with-buffer.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/with-buffer.ts) | `bufN` binary fields |
 | [`wstring.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/wstring.ts) | UTF-16LE wide strings |
@@ -855,6 +879,10 @@ Runnable scripts live in [`/examples`](https://github.com/MrHIDEn/cstruct/tree/m
 Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/examples/README.md).
 
 ## Changelog
+
+### What's new in 1.6.0
+* Added `CStructBE.fromCompiled(jsonModel)` and `CStructLE.fromCompiled(jsonModel)` — load a precompiled model without running `ModelParser.parseModel`
+* Added [`examples/from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts) and README section [Precompiled models](#precompiled-models-fromcompiled)
 
 ### What's new in 1.5.5
 * Reorganized README into Basic / Advanced / Specialized paths with TOC and Quick start

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ console.log(cStruct.read(buffer).struct);
 
 `fromCompiled` accepts a JSON string or a parsed object/array (the same shape as `jsonModel`). See [`examples/from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts).
 
+**Security note:** Treat `jsonModel` as a **trusted build-time artifact** (same trust level as your own source code). `fromCompiled` only checks that the input is valid JSON (object or array) — it does **not** re-run `ModelParser` and does **not** limit size or nesting depth. Do not load `jsonModel` from untrusted sources (user upload, arbitrary URL, unverified remote config): a malicious payload can cause high memory/CPU use (`JSON.parse` on a huge or deeply nested document). Prefer compiling with `fromModelTypes` in your build and shipping the resulting string as a constant or a file you control.
+
 ### Nested types and AtomTypes
 
 ```javascript
@@ -883,6 +885,7 @@ Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/
 ### What's new in 1.6.0
 * Added `CStructBE.fromCompiled(jsonModel)` and `CStructLE.fromCompiled(jsonModel)` — load a precompiled model without running `ModelParser.parseModel`
 * Added [`examples/from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts) and README section [Precompiled models](#precompiled-models-fromcompiled)
+* Documented that `jsonModel` must be treated as a trusted build-time artifact (do not load from untrusted sources)
 
 ### What's new in 1.5.5
 * Reorganized README into Basic / Advanced / Specialized paths with TOC and Quick start

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ Runnable scripts in this folder. Build first (`npm run build`), then run with `n
 | [`string-model.ts`](./string-model.ts) | String-based models, LE vs BE |
 | [`string-model-types.ts`](./string-model-types.ts) | String models + named types |
 | [`little-endian.ts`](./little-endian.ts) | BE vs LE side-by-side |
+| [`from-compiled.ts`](./from-compiled.ts) | Precompiled `jsonModel` / `fromCompiled` |
 | [`write-offset.ts`](./write-offset.ts) | `make` vs `write` with offset |
 | [`with-buffer.ts`](./with-buffer.ts) | `bufN` / binary buffer fields |
 | [`wstring.ts`](./wstring.ts) | `wsN` / UTF-16LE wide strings |

--- a/examples/from-compiled.ts
+++ b/examples/from-compiled.ts
@@ -17,6 +17,7 @@ import { CStructBE, CStructLE } from "../src";
     fs.writeFileSync(tmpFile, jsonModel, 'utf8');
 
     // Runtime: load precompiled model without ModelParser.parseModel
+    // Only load jsonModel from a trusted source you control (not user upload / arbitrary URL).
     const loadedJsonModel = fs.readFileSync(tmpFile, 'utf8');
     const cStructBe = CStructBE.fromCompiled(loadedJsonModel);
     const cStructLe = CStructLE.fromCompiled(JSON.parse(loadedJsonModel));

--- a/examples/from-compiled.ts
+++ b/examples/from-compiled.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CStructBE, CStructLE } from "../src";
+
+{
+    const model = { a: 'u16', b: 'i16' };
+    const data = { a: 10, b: -10 };
+
+    // Build time: compile model once and persist jsonModel
+    const compiled = CStructBE.fromModelTypes(model);
+    const jsonModel = compiled.jsonModel;
+    console.log('Compiled jsonModel:', jsonModel);
+    // {"a":"u16","b":"i16"}
+
+    const tmpFile = path.join(os.tmpdir(), 'cstruct-from-compiled-model.json');
+    fs.writeFileSync(tmpFile, jsonModel, 'utf8');
+
+    // Runtime: load precompiled model without ModelParser.parseModel
+    const loadedJsonModel = fs.readFileSync(tmpFile, 'utf8');
+    const cStructBe = CStructBE.fromCompiled(loadedJsonModel);
+    const cStructLe = CStructLE.fromCompiled(JSON.parse(loadedJsonModel));
+
+    const beBuffer = cStructBe.make(data).buffer;
+    const leBuffer = cStructLe.make(data).buffer;
+
+    console.log('BE make:', beBuffer.toString('hex'));
+    // 000afff6
+    console.log('LE make:', leBuffer.toString('hex'));
+    // 0a00f6ff
+
+    console.log('BE read:', cStructBe.read(beBuffer).struct);
+    console.log('LE read:', cStructLe.read(leBuffer).struct);
+    // both: { a: 10, b: -10 }
+
+    fs.unlinkSync(tmpFile);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrhiden/cstruct",
-      "version": "1.5.5",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "@mrhiden/cstruct": "1.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "description": "For packing and unpacking bytes (C like structures) in/from Buffer based on Object/Array type for parsing.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/cstruct-be.ts
+++ b/src/cstruct-be.ts
@@ -15,8 +15,8 @@ import { Class, CStructClassOptions } from "./decorators-types";
  * Uses Object, JSON, C_Struct lang (kind of C)
  */
 export class CStructBE<T> extends CStruct<T> {
-    private constructor(model: Model, types?: Types) {
-        super(model, types);
+    private constructor(model?: Model, types?: Types, compiledJsonModel?: string) {
+        super(model, types, compiledJsonModel);
     }
 
     make<T = any>(struct: T): CStructWriteResult {
@@ -70,5 +70,10 @@ export class CStructBE<T> extends CStruct<T> {
 
     static fromModelTypes<T = any>(model: Model, types?: Types): CStructBE<T> {
         return new CStructBE<T>(model, types);
+    }
+
+    static fromCompiled<T = any>(jsonModel: string | Model): CStructBE<T> {
+        const normalized = CStruct.normalizeCompiledJsonModel(jsonModel);
+        return new CStructBE<T>(undefined, undefined, normalized);
     }
 }

--- a/src/cstruct-le.ts
+++ b/src/cstruct-le.ts
@@ -15,8 +15,8 @@ import { Class, CStructClassOptions } from "./decorators-types";
  * Uses Object, JSON, C_Struct lang (kind of C)
  */
 export class CStructLE<T> extends CStruct<T> {
-    constructor(model: Model, types?: Types) {
-        super(model, types);
+    constructor(model?: Model, types?: Types, compiledJsonModel?: string) {
+        super(model, types, compiledJsonModel);
     }
 
     make<T = any>(struct: T): CStructWriteResult {
@@ -70,5 +70,10 @@ export class CStructLE<T> extends CStruct<T> {
 
     static fromModelTypes<T = any>(model: Model, types?: Types): CStructLE<T> {
         return new CStructLE<T>(model, types);
+    }
+
+    static fromCompiled<T = any>(jsonModel: string | Model): CStructLE<T> {
+        const normalized = CStruct.normalizeCompiledJsonModel(jsonModel);
+        return new CStructLE<T>(undefined, undefined, normalized);
     }
 }

--- a/src/cstruct.ts
+++ b/src/cstruct.ts
@@ -6,9 +6,27 @@ export class CStruct<T> {
     protected _jsonModel: string;
     protected _jsonTypes: Types;
 
-    constructor(model: Model, types?: Types) {
+    constructor(model?: Model, types?: Types, compiledJsonModel?: string) {
         this._jsonTypes = types;
-        this._jsonModel = ModelParser.parseModel(model, types);
+        if (compiledJsonModel !== undefined) {
+            this._jsonModel = CStruct.normalizeCompiledJsonModel(compiledJsonModel);
+        } else {
+            this._jsonModel = ModelParser.parseModel(model, types);
+        }
+    }
+
+    static normalizeCompiledJsonModel(input: string | Model): string {
+        const json = typeof input === 'string' ? input : JSON.stringify(input);
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(json);
+        } catch {
+            throw new Error('Compiled model must be valid JSON.');
+        }
+        if (parsed === null || typeof parsed !== 'object') {
+            throw new Error('Compiled model must be a JSON object or array.');
+        }
+        return json;
     }
 
     get jsonTypes(): string {

--- a/tests/from-compiled.test.ts
+++ b/tests/from-compiled.test.ts
@@ -1,0 +1,111 @@
+import { CStructBE, CStructLE, hexToBuffer } from "../src";
+
+
+describe('fromCompiled', () => {
+    const simpleModel = { a: 'u16', b: 'i16' };
+    const simpleData = { a: 10, b: -10 };
+
+    describe('BE', () => {
+        it('should read the same as fromModelTypes', () => {
+            const compiled = CStructBE.fromModelTypes(simpleModel);
+            const fromTypes = CStructBE.fromModelTypes(simpleModel);
+            const fromCompiled = CStructBE.fromCompiled(compiled.jsonModel);
+            const buffer = hexToBuffer('000AFFF6');
+
+            expect(fromCompiled.read(buffer)).toEqual(fromTypes.read(buffer));
+        });
+
+        it('should make the same as fromModelTypes', () => {
+            const compiled = CStructBE.fromModelTypes(simpleModel);
+            const fromTypes = CStructBE.fromModelTypes(simpleModel);
+            const fromCompiled = CStructBE.fromCompiled(compiled.jsonModel);
+
+            expect(fromCompiled.make(simpleData)).toEqual(fromTypes.make(simpleData));
+        });
+
+        it('should write the same as fromModelTypes', () => {
+            const compiled = CStructBE.fromModelTypes(simpleModel);
+            const fromTypes = CStructBE.fromModelTypes(simpleModel);
+            const fromCompiled = CStructBE.fromCompiled(compiled.jsonModel);
+            const buffer = hexToBuffer('00000000');
+
+            expect(fromCompiled.write(buffer, simpleData)).toEqual(fromTypes.write(buffer, simpleData));
+        });
+
+        it('should accept compiled model as object', () => {
+            const compiled = CStructBE.fromModelTypes(simpleModel);
+            const parsed = JSON.parse(compiled.jsonModel);
+            const fromCompiled = CStructBE.fromCompiled(parsed);
+            const buffer = hexToBuffer('000AFFF6');
+
+            expect(fromCompiled.read(buffer).struct).toEqual(simpleData);
+        });
+
+        it('should round-trip complex model with named types and dynamic array', () => {
+            const model = { ab: 'Ab[i16]' };
+            const types = { Ab: { a: 'i8', b: 'i8' } };
+            const compiled = CStructBE.fromModelTypes(model, types);
+            const jsonModel = compiled.jsonModel;
+            const cStruct = CStructBE.fromCompiled(jsonModel);
+            const struct = {
+                ab: [
+                    { a: -1, b: +1 },
+                    { a: -2, b: +2 },
+                ],
+            };
+            const expected = hexToBuffer('0002_FF_01_FE_02');
+
+            const makeResult = cStruct.make(struct);
+            expect(makeResult.buffer).toEqual(expected);
+
+            const readResult = cStruct.read(makeResult.buffer);
+            expect(readResult.struct).toEqual(struct);
+        });
+    });
+
+    describe('LE', () => {
+        it('should read the same as fromModelTypes', () => {
+            const compiled = CStructLE.fromModelTypes(simpleModel);
+            const fromTypes = CStructLE.fromModelTypes(simpleModel);
+            const fromCompiled = CStructLE.fromCompiled(compiled.jsonModel);
+            const buffer = hexToBuffer('0A00F6FF');
+
+            expect(fromCompiled.read(buffer)).toEqual(fromTypes.read(buffer));
+        });
+
+        it('should make the same as fromModelTypes', () => {
+            const compiled = CStructLE.fromModelTypes(simpleModel);
+            const fromTypes = CStructLE.fromModelTypes(simpleModel);
+            const fromCompiled = CStructLE.fromCompiled(compiled.jsonModel);
+
+            expect(fromCompiled.make(simpleData)).toEqual(fromTypes.make(simpleData));
+        });
+
+        it('should write the same as fromModelTypes', () => {
+            const compiled = CStructLE.fromModelTypes(simpleModel);
+            const fromTypes = CStructLE.fromModelTypes(simpleModel);
+            const fromCompiled = CStructLE.fromCompiled(compiled.jsonModel);
+            const buffer = hexToBuffer('00000000');
+
+            expect(fromCompiled.write(buffer, simpleData)).toEqual(fromTypes.write(buffer, simpleData));
+        });
+    });
+
+    describe('validation', () => {
+        it('should throw on invalid JSON string', () => {
+            expect(() => CStructBE.fromCompiled('{not json}')).toThrow('Compiled model must be valid JSON.');
+        });
+
+        it('should throw on null', () => {
+            expect(() => CStructBE.fromCompiled('null')).toThrow('Compiled model must be a JSON object or array.');
+        });
+
+        it('should throw on number', () => {
+            expect(() => CStructBE.fromCompiled('42')).toThrow('Compiled model must be a JSON object or array.');
+        });
+
+        it('should throw on string primitive', () => {
+            expect(() => CStructBE.fromCompiled('"hello"')).toThrow('Compiled model must be a JSON object or array.');
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add `CStructBE.fromCompiled(jsonModel)` and `CStructLE.fromCompiled(jsonModel)` to load a precompiled model without running `ModelParser.parseModel`
- Accept JSON string or parsed object/array; light validation on load
- Non-breaking: existing `fromModelTypes`, decorators, and read/write/make APIs unchanged

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 610 tests pass (including new `tests/from-compiled.test.ts`)
- [x] `npm run build`
- [x] Equivalence tests: `fromModelTypes` vs `fromCompiled(c.jsonModel)` for read/make/write (BE & LE)
- [x] Round-trip on complex model with named types + dynamic array
- [x] Validation errors for invalid JSON, null, primitives
- [ ] Manual: `npx ts-node examples/from-compiled.ts`


Made with [Cursor](https://cursor.com)