### PR TITLE
POC: immutable schema — cache parsedModel, eliminate JSON.parse per read

### DIFF
--- a/src/cstruct-be.ts
+++ b/src/cstruct-be.ts
@@ -20,7 +20,7 @@ export class CStructBE<T> extends CStruct<T> {
     }
 
     make<T = any>(struct: T): CStructWriteResult {
-        const writer = new MakeBE<T>(this.modelClone, struct);
+        const writer = new MakeBE<T>(this.parsedModel, struct);
         return {
             buffer: writer.toBuffer(),
             offset: writer.offset,
@@ -29,7 +29,7 @@ export class CStructBE<T> extends CStruct<T> {
     }
 
     write<T = any>(buffer: Buffer, struct: T, offset = 0): CStructWriteResult {
-        const writer = new WriteBE<T>(this.modelClone, struct, buffer, offset);
+        const writer = new WriteBE<T>(this.parsedModel, struct, buffer, offset);
         return {
             buffer: writer.toBuffer(),
             offset: writer.offset,
@@ -38,7 +38,7 @@ export class CStructBE<T> extends CStruct<T> {
     }
 
     read<T = any>(buffer: Buffer, offset = 0): CStructReadResult<T> {
-        const reader = new ReadBE<T>(this.modelClone, buffer, offset);
+        const reader = new ReadBE<T>(this.parsedModel, buffer, offset);
         return {
             struct: reader.toStruct(),
             offset: reader.offset,

--- a/src/cstruct-le.ts
+++ b/src/cstruct-le.ts
@@ -20,7 +20,7 @@ export class CStructLE<T> extends CStruct<T> {
     }
 
     make<T = any>(struct: T): CStructWriteResult {
-        const writer = new MakeLE<T>(this.modelClone, struct);
+        const writer = new MakeLE<T>(this.parsedModel, struct);
         return {
             buffer: writer.toBuffer(),
             offset: writer.offset,
@@ -29,7 +29,7 @@ export class CStructLE<T> extends CStruct<T> {
     }
 
     write<T = any>(buffer: Buffer, struct: T, offset = 0): CStructWriteResult {
-        const writer = new WriteLE<T>(this.modelClone, struct, buffer, offset);
+        const writer = new WriteLE<T>(this.parsedModel, struct, buffer, offset);
         return {
             buffer: writer.toBuffer(),
             offset: writer.offset,
@@ -38,7 +38,7 @@ export class CStructLE<T> extends CStruct<T> {
     }
 
     read<T = any>(buffer: Buffer, offset = 0): CStructReadResult<T> {
-        const reader = new ReadLE<T>(this.modelClone, buffer, offset);
+        const reader = new ReadLE<T>(this.parsedModel, buffer, offset);
         return {
             struct: reader.toStruct() as T,
             offset: reader.offset,

--- a/src/cstruct.ts
+++ b/src/cstruct.ts
@@ -5,6 +5,7 @@ import { ModelParser } from "./model-parser";
 export class CStruct<T> {
     protected _jsonModel: string;
     protected _jsonTypes: Types;
+    protected _parsedModel: Model;
 
     constructor(model?: Model, types?: Types, compiledJsonModel?: string) {
         this._jsonTypes = types;
@@ -13,6 +14,7 @@ export class CStruct<T> {
         } else {
             this._jsonModel = ModelParser.parseModel(model, types);
         }
+        this._parsedModel = JSON.parse(this._jsonModel) as Model;
     }
 
     static normalizeCompiledJsonModel(input: string | Model): string {
@@ -37,8 +39,12 @@ export class CStruct<T> {
         return this._jsonModel;
     }
 
+    get parsedModel(): Model {
+        return this._parsedModel;
+    }
+
     get modelClone(): Model {
-        return JSON.parse(this._jsonModel) as Model;
+        return this._parsedModel;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/make.ts
+++ b/src/make.ts
@@ -6,25 +6,34 @@ import { ReadWriteBase } from "./read-write-base";
 export class Make<T> extends ReadWriteBase {
     protected _writer: WriteBufferLE | WriteBufferBE;
 
+    /**
+     * Walk the compiled model and struct value, writing bytes to the internal buffer.
+     * The model is never mutated — only the output buffer grows.
+     */
     recursion(model: Model, struct: T) {
         const entries: StructEntry[] = Object.entries(model);
 
         for (const [modelKey, modelType] of entries) {
-            // Catch key.length
+            // Catch dynamic key — e.g. "some.i16" or "some.5"
             const keyLengthGroups = this.getDynamicTypeLengthGroupsMatch(modelKey);
 
-            // Dynamic key
+            // Dynamic key: field name carries type/length, value is the item type
+            // 1 (some.i16: u8)
+            // 2 (some.5  : u8)
             if (keyLengthGroups) {
                 const {dynamicType, dynamicLength} = keyLengthGroups;
                 this.writDynamicOrStatic(struct, modelType as string, dynamicLength, dynamicType, modelType as string);
                 continue;
             }
 
-            // Dynamic type
+            // Dynamic type: type string carries length, key is the struct field name
             if (typeof modelType === 'string') {
-                // Catch dynamic type
+                // Catch dynamic type — e.g. "u8.i16" or "u8.5"
                 const typeDynamicGroups = this.getDynamicTypeLengthGroupsMatch(modelType);
 
+                // Dynamic type
+                // 1 (u8.i16) (<dynamicType>.<dynamicLength>)
+                // 2 (u8.5)   (<dynamicType>.<dynamicLength>)
                 if (typeDynamicGroups) {
                     const {dynamicType, dynamicLength} = typeDynamicGroups;
                     this.writDynamicOrStatic(struct, dynamicType, dynamicLength, modelKey, dynamicType);
@@ -32,7 +41,7 @@ export class Make<T> extends ReadWriteBase {
                 }
             }
 
-            // Static item
+            // Static field — scalar or nested struct
             this.write(model, struct, modelKey, modelType);
         }
     }
@@ -60,6 +69,7 @@ export class Make<T> extends ReadWriteBase {
             throw new Error(`Size of value ${structValues.length} is greater than ${staticSize}.`);
         }
 
+        // Size: use static length from the model, or derive from the struct value
         const size = isStatic
             ? staticSize
             : structValues.length;
@@ -68,18 +78,17 @@ export class Make<T> extends ReadWriteBase {
             throw new Error(`Buffer size can not be 0.`);
         }
 
-        // Dynamic, write size before value
+        // Dynamic length — write size prefix before the value
         if (!isStatic) {
             this._writer.write(dynamicLength, size);
         }
 
-        // Write string or buffer or json
+        // Write string, wstring, buffer, or json blob
         if (specialType) {
-            // this._writer.write(writeType, structValues, isStatic && (passSize || size === 0) ? size : undefined);
             this._writer.write(writeType, structValues, isStatic ? size : undefined);
         }
 
-        // Write array of writeType
+        // Write array of itemsType (structValues.length elements)
         else {
             this.writeArray(writeType, structValues);
         }
@@ -88,9 +97,11 @@ export class Make<T> extends ReadWriteBase {
     private write(model: Model, struct: T, modelKey: string, modelType: Type) {
         let structValues: WriterValue;
         switch (typeof modelType) {
+            // Nested struct object
             case 'object':
                 this.recursion(model[modelKey], struct[modelKey]);
                 break;
+            // Static scalar — u8, i16, j0, buf, wstring, ...
             case 'string':
                 if (modelType === 'buf0') {
                     throw new Error(`Buffer size can not be 0. (make)`);
@@ -108,11 +119,13 @@ export class Make<T> extends ReadWriteBase {
 
     private writeArray(itemsType: Type, structValues: T[]) {
         switch (typeof itemsType) {
+            // Array of nested structs — encode each element's sub-tree
             case 'object':
                 for (const structValue of structValues) {
                     this.recursion(itemsType, structValue);
                 }
                 break;
+            // Array of scalars — repeat the same type string for each element
             case 'string':
                 for (const structValue of structValues) {
                     this._writer.write(itemsType, structValue as WriterValue);

--- a/src/read-be.ts
+++ b/src/read-be.ts
@@ -6,7 +6,6 @@ export class ReadBE<T> extends Read<T> {
     constructor(model: Model, buffer: Buffer, offset = 0) {
         super();
         this._reader = new ReadBufferBE(buffer, offset);
-        this._struct = model as T;
-        this.recursion(this._struct);
+        this._struct = this.readSchema(model) as T;
     }
 }

--- a/src/read-le.ts
+++ b/src/read-le.ts
@@ -6,7 +6,6 @@ export class ReadLE<T> extends Read<T> {
     constructor(model: Model, buffer: Buffer, offset = 0) {
         super();
         this._reader = new ReadBufferLE(buffer, offset);
-        this._struct = model as T;
-        this.recursion(this._struct);
+        this._struct = this.readSchema(model) as T;
     }
 }

--- a/src/read.ts
+++ b/src/read.ts
@@ -1,6 +1,6 @@
 import { ReadBufferBE } from "./read-buffer-be";
 import { ReadBufferLE } from "./read-buffer-le";
-import { ReaderValue, SpecialType, StructEntry, Type } from "./types";
+import { Model, SpecialType, StructValue, Type } from "./types";
 import { ReadWriteBase } from "./read-write-base";
 
 
@@ -8,53 +8,62 @@ export class Read<T> extends ReadWriteBase {
     protected _struct: T;
     protected _reader: ReadBufferLE | ReadBufferBE;
 
-    recursion(struct: T) {
-        const entries: StructEntry[] = Object.entries(struct);
+    readSchema(model: Model): StructValue {
+        if (Array.isArray(model)) {
+            const result: StructValue[] = [];
+            for (let i = 0; i < model.length; i++) {
+                result[i] = this.readField(model[i]);
+            }
+            return result;
+        }
 
-        for (const [modelKey, modelType] of entries) {
-            // Catch dynamic key
+        const result: Record<string, StructValue> = {};
+        for (const [modelKey, modelType] of Object.entries(model)) {
             const keyDynamicGroups = this.getDynamicTypeLengthGroupsMatch(modelKey);
 
-            // Dynamic key
             if (keyDynamicGroups) {
-                delete struct[modelKey];
-                const {dynamicType, dynamicLength} = keyDynamicGroups;
-                this.readDynamicOrStatic(struct, modelType as string, dynamicType, dynamicLength, modelType as string, dynamicType);
+                const { dynamicType, dynamicLength } = keyDynamicGroups;
+                result[dynamicType] = this.readDynamicOrStaticValue(
+                    modelType as string,
+                    dynamicType,
+                    dynamicLength,
+                    modelType as string,
+                );
                 continue;
             }
 
-            // Dynamic type
             if (typeof modelType === 'string') {
-                // Catch dynamic type
                 const typeDynamicGroups = this.getDynamicTypeLengthGroupsMatch(modelType);
 
                 if (typeDynamicGroups) {
-                    const {dynamicType, dynamicLength} = typeDynamicGroups;
-                    this.readDynamicOrStatic(struct, dynamicType, dynamicType, dynamicLength, dynamicType, modelKey);
+                    const { dynamicType, dynamicLength } = typeDynamicGroups;
+                    result[modelKey] = this.readDynamicOrStaticValue(
+                        dynamicType,
+                        dynamicType,
+                        dynamicLength,
+                        dynamicType,
+                    );
                     continue;
                 }
             }
 
-            // Static item
-            this.read(struct, modelKey, modelType);
+            result[modelKey] = this.readField(modelType);
         }
+        return result;
     }
 
-    private readDynamicOrStatic(struct: T, modelType: string, dynamicType: string, dynamicLength: string, readType: string, structKey: string) {
-        // Dynamic key
-        // 1 (some.i16: u8)
-        // 2 (some.5  : u8)
-        // Dynamic type
-        // 1 (u8.i16) (<dynamicType>.<dynamicLength>)
-        // 2 (u8.5)   (<dynamicType>.<dynamicLength>)
-
+    private readDynamicOrStaticValue(
+        modelType: string,
+        dynamicType: string,
+        dynamicLength: string,
+        readType: string,
+    ): StructValue {
         const {
             specialType,
             isStatic,
             staticSize
         } = this.extractTypeAndSize(modelType, dynamicLength);
 
-        // Size, get or read
         const size = isStatic
             ? staticSize
             : this._reader.read(dynamicLength) as number;
@@ -63,51 +72,64 @@ export class Read<T> extends ReadWriteBase {
             throw new Error(`Buffer size can not be 0.`);
         }
 
-        // Read string or wstring or buffer or json
         if (specialType) {
             const value = this._reader.read(readType, size);
-            struct[structKey] = specialType === SpecialType.Json ? JSON.parse(value as string) : value;
+            return specialType === SpecialType.Json ? JSON.parse(value as string) : value;
         }
 
-        // Read array of itemsType
-        else {
-            this.readArray(readType, struct, structKey, size);
-        }
+        return this.readArrayValue(readType, size);
     }
 
-    private read(struct: T, modelKey: string, modelType: Type) {
-        let structValues: ReaderValue;
-        switch (typeof modelType) {
-            case 'object':
-                this.recursion(struct[modelKey]);
-                break;
-            case 'string':
-                if (modelType === 'buf0') {
-                    throw new Error(`Buffer size can not be 0. (read)`);
-                }
-                structValues = this._reader.read(modelType);
-                if (modelType === 'j0') {
-                    structValues = JSON.parse(structValues as string);
-                }
-                struct[modelKey] = structValues;
-                break;
-            default:
-                throw TypeError(`Unknown type "${modelType}"`);
+    private readField(modelType: Type): StructValue {
+        if (Array.isArray(modelType)) {
+            return this.readSchema(modelType);
         }
+
+        if (typeof modelType === 'string') {
+            const typeDynamicGroups = this.getDynamicTypeLengthGroupsMatch(modelType);
+            if (typeDynamicGroups) {
+                const { dynamicType, dynamicLength } = typeDynamicGroups;
+                return this.readDynamicOrStaticValue(
+                    dynamicType,
+                    dynamicType,
+                    dynamicLength,
+                    dynamicType,
+                );
+            }
+
+            if (modelType === 'buf0') {
+                throw new Error(`Buffer size can not be 0. (read)`);
+            }
+            let structValues = this._reader.read(modelType);
+            if (modelType === 'j0') {
+                structValues = JSON.parse(structValues as string);
+            }
+            return structValues;
+        }
+
+        if (typeof modelType === 'object') {
+            return this.readSchema(modelType as Model);
+        }
+
+        throw TypeError(`Unknown type "${modelType}"`);
     }
 
-    private readArray(itemsType: Type, struct: T, dynamicKey: string, size: number) {
+    private readArrayValue(itemsType: Type, size: number): StructValue {
         switch (typeof itemsType) {
             case 'object': {
-                const json = JSON.stringify(itemsType);
-                struct[dynamicKey] = Array(size).fill(0).map(() => JSON.parse(json));
-                this.recursion(struct[dynamicKey]);
-                break;
+                const result: StructValue[] = [];
+                for (let i = 0; i < size; i++) {
+                    result[i] = this.readSchema(itemsType as Model);
+                }
+                return result;
             }
-            case 'string':
-                struct[dynamicKey] = Array(size).fill(itemsType);
-                this.recursion(struct[dynamicKey]);
-                break;
+            case 'string': {
+                const result: StructValue[] = [];
+                for (let i = 0; i < size; i++) {
+                    result[i] = this.readField(itemsType);
+                }
+                return result;
+            }
             default:
                 throw TypeError(`Unknown type "${itemsType}"`);
         }

--- a/src/read.ts
+++ b/src/read.ts
@@ -8,7 +8,12 @@ export class Read<T> extends ReadWriteBase {
     protected _struct: T;
     protected _reader: ReadBufferLE | ReadBufferBE;
 
+    /**
+     * Walk the compiled model and build a fresh struct value.
+     * The model is never mutated — the result is a new object/array tree.
+     */
     readSchema(model: Model): StructValue {
+        // Tuple model: [{ u8 }, { u16 }] → [value0, value1, ...]
         if (Array.isArray(model)) {
             const result: StructValue[] = [];
             for (let i = 0; i < model.length; i++) {
@@ -19,8 +24,12 @@ export class Read<T> extends ReadWriteBase {
 
         const result: Record<string, StructValue> = {};
         for (const [modelKey, modelType] of Object.entries(model)) {
+            // Catch dynamic key — e.g. "some.i16" or "some.5"
             const keyDynamicGroups = this.getDynamicTypeLengthGroupsMatch(modelKey);
 
+            // Dynamic key: field name carries type/length, value is the item type
+            // 1 (some.i16: u8)
+            // 2 (some.5  : u8)
             if (keyDynamicGroups) {
                 const { dynamicType, dynamicLength } = keyDynamicGroups;
                 result[dynamicType] = this.readDynamicOrStaticValue(
@@ -32,9 +41,14 @@ export class Read<T> extends ReadWriteBase {
                 continue;
             }
 
+            // Dynamic type: type string carries length, key is the struct field name
             if (typeof modelType === 'string') {
+                // Catch dynamic type — e.g. "u8.i16" or "u8.5"
                 const typeDynamicGroups = this.getDynamicTypeLengthGroupsMatch(modelType);
 
+                // Dynamic type
+                // 1 (u8.i16) (<dynamicType>.<dynamicLength>)
+                // 2 (u8.5)   (<dynamicType>.<dynamicLength>)
                 if (typeDynamicGroups) {
                     const { dynamicType, dynamicLength } = typeDynamicGroups;
                     result[modelKey] = this.readDynamicOrStaticValue(
@@ -47,6 +61,7 @@ export class Read<T> extends ReadWriteBase {
                 }
             }
 
+            // Static field — scalar, nested struct, or fixed tuple
             result[modelKey] = this.readField(modelType);
         }
         return result;
@@ -64,6 +79,7 @@ export class Read<T> extends ReadWriteBase {
             staticSize
         } = this.extractTypeAndSize(modelType, dynamicLength);
 
+        // Size: use static length from the model, or read it from the buffer first
         const size = isStatic
             ? staticSize
             : this._reader.read(dynamicLength) as number;
@@ -72,20 +88,24 @@ export class Read<T> extends ReadWriteBase {
             throw new Error(`Buffer size can not be 0.`);
         }
 
+        // Read string, wstring, buffer, or json blob
         if (specialType) {
             const value = this._reader.read(readType, size);
             return specialType === SpecialType.Json ? JSON.parse(value as string) : value;
         }
 
+        // Read array of itemsType (size elements)
         return this.readArrayValue(readType, size);
     }
 
     private readField(modelType: Type): StructValue {
+        // Tuple element or nested array model
         if (Array.isArray(modelType)) {
             return this.readSchema(modelType);
         }
 
         if (typeof modelType === 'string') {
+            // Dynamic type inside a tuple — e.g. "j.0" or "s.0"
             const typeDynamicGroups = this.getDynamicTypeLengthGroupsMatch(modelType);
             if (typeDynamicGroups) {
                 const { dynamicType, dynamicLength } = typeDynamicGroups;
@@ -97,6 +117,7 @@ export class Read<T> extends ReadWriteBase {
                 );
             }
 
+            // Static scalar — u8, i16, j0, buf, wstring, ...
             if (modelType === 'buf0') {
                 throw new Error(`Buffer size can not be 0. (read)`);
             }
@@ -107,6 +128,7 @@ export class Read<T> extends ReadWriteBase {
             return structValues;
         }
 
+        // Nested struct object
         if (typeof modelType === 'object') {
             return this.readSchema(modelType as Model);
         }
@@ -116,6 +138,7 @@ export class Read<T> extends ReadWriteBase {
 
     private readArrayValue(itemsType: Type, size: number): StructValue {
         switch (typeof itemsType) {
+            // Array of nested structs — each element gets its own sub-tree
             case 'object': {
                 const result: StructValue[] = [];
                 for (let i = 0; i < size; i++) {
@@ -123,6 +146,7 @@ export class Read<T> extends ReadWriteBase {
                 }
                 return result;
             }
+            // Array of scalars — repeat the same type string size times
             case 'string': {
                 const result: StructValue[] = [];
                 for (let i = 0; i < size; i++) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type WriterValue = number | string | bigint | boolean | Buffer;
 export type ReaderValue = number | string | bigint | boolean | Buffer;
+export type StructValue = ReaderValue | StructValue[] | { [key: string]: StructValue };
 export type ModelValue = number | string | bigint | boolean | Buffer;
 export type WriterFunctions = (val: WriterValue, size?: number) => void;
 export type ReaderFunctions = (size?: number) => ReaderValue;

--- a/src/write.ts
+++ b/src/write.ts
@@ -1,5 +1,9 @@
 import { Make } from "./make";
 
+/**
+ * Write encoded bytes into a pre-allocated buffer at a given offset.
+ * Encoding logic lives in Make (via recursion); this class only copies the result.
+ */
 export class Write<T> extends Make<T> {
     _buffer: Buffer;
     _offset: number;
@@ -10,6 +14,7 @@ export class Write<T> extends Make<T> {
         this._offset = offset;
     }
 
+    // Encode struct into an internal buffer, then copy into the target buffer at _offset
     toBuffer() {
         const makeBuffer = this._writer.toBuffer();
         const leftSpace = this._buffer.length - this._offset;
@@ -20,6 +25,7 @@ export class Write<T> extends Make<T> {
         return this._buffer;
     }
 
+    // Cursor position after the write (start offset + bytes written)
     get offset() {
         return this._offset + this.size;
     }

--- a/tests/immutable-schema.test.ts
+++ b/tests/immutable-schema.test.ts
@@ -1,0 +1,50 @@
+import { CStructBE, CStructLE, hexToBuffer } from "../src";
+
+
+describe('immutable schema POC', () => {
+    const model = { a: 'u16', b: 'i16' };
+    const data = { a: 10, b: -10 };
+    const bufferBe = hexToBuffer('000AFFF6');
+    const bufferLe = hexToBuffer('0A00F6FF');
+
+    it('should keep parsedModel reference stable across reads (BE)', () => {
+        const cStruct = CStructBE.fromModelTypes(model);
+        const schemaBefore = cStruct.parsedModel;
+
+        const first = cStruct.read(bufferBe);
+        const schemaAfterFirst = cStruct.parsedModel;
+        const second = cStruct.read(bufferBe);
+
+        expect(schemaBefore).toBe(schemaAfterFirst);
+        expect(first.struct).toEqual(data);
+        expect(second.struct).toEqual(data);
+    });
+
+    it('should keep parsedModel reference stable across reads (LE)', () => {
+        const cStruct = CStructLE.fromModelTypes(model);
+        const schemaBefore = cStruct.parsedModel;
+
+        cStruct.read(bufferLe);
+        const schemaAfter = cStruct.parsedModel;
+
+        expect(schemaBefore).toBe(schemaAfter);
+    });
+
+    it('should keep parsedModel stable across make operations (BE)', () => {
+        const cStruct = CStructBE.fromModelTypes(model);
+        const schemaBefore = cStruct.parsedModel;
+
+        const first = cStruct.make(data);
+        const schemaAfterFirst = cStruct.parsedModel;
+        const second = cStruct.make(data);
+
+        expect(schemaBefore).toBe(schemaAfterFirst);
+        expect(first.buffer).toEqual(second.buffer);
+    });
+
+    it('modelClone should return the same cached schema object', () => {
+        const cStruct = CStructBE.fromModelTypes(model);
+
+        expect(cStruct.modelClone).toBe(cStruct.parsedModel);
+    });
+});


### PR DESCRIPTION
## Summary
- Cache compiled model as `_parsedModel` once in `CStruct` constructor; `modelClone` / `parsedModel` return the same reference
- Refactor `Read` to immutable `readSchema()` — builds a fresh result tree without mutating the schema (replaces in-place `recursion`)
- Wire `CStructBE` / `CStructLE` to use `parsedModel` in `make`, `write`, and `read`
- Add `tests/immutable-schema.test.ts` verifying schema reference stability across multiple reads
- Restore inline comments in `read.ts` documenting dynamic key/type handling

## Test plan
- [x] `npm run lint`
- [x] `npm test` — 614/614 passed
- [x] `npm run build`


Made with [Cursor](https://cursor.com)