### PR TITLE
Release 1.6.1: immutable schema changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,12 @@ Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/
 
 ## Changelog
 
+### What's new in 1.6.1
+* **Immutable schema (read path):** `read` no longer mutates the compiled model — it builds a fresh result tree via `readSchema`
+* **Cached `parsedModel`:** the compiled model is parsed once in the constructor and reused across `read`, `write`, and `make` (eliminates `JSON.parse` per operation)
+* Added getter `parsedModel` — returns the cached compiled model object
+* **`modelClone` behavior:** now returns the same cached schema reference as `parsedModel` (do not mutate in place)
+
 ### What's new in 1.6.0
 * Added `CStructBE.fromCompiled(jsonModel)` and `CStructLE.fromCompiled(jsonModel)` — load a precompiled model without running `ModelParser.parseModel`
 * Added [`examples/from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts) and README section [Precompiled models](#precompiled-models-fromcompiled)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mrhiden/cstruct",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "devDependencies": {
         "@mrhiden/cstruct": "1.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "For packing and unpacking bytes (C like structures) in/from Buffer based on Object/Array type for parsing.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump version to 1.6.1
- Add README changelog for immutable read path, cached `parsedModel`, and `modelClone` behavior change

## Test plan
- [x] Docs-only release bump — no code changes


Made with [Cursor](https://cursor.com)