### PR TITLE
feat: codegen compileRead/compileWrite/compileMake (1.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,7 +922,7 @@ Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/
 ### What's new in 1.7.0
 * Added `compileRead`, `compileWrite`, `compileMake` on `CStructBE` and `CStructLE` — compile a model once into specialized functions for high-throughput read/write/make
 * Instance methods `cStruct.compileRead()` / `compileWrite()` / `compileMake()` use cached `parsedModel`
-* `compileMake` uses single `allocUnsafe` for fully static models and `chunks + concat` for variable-length fields
+* `compileMake` uses single `allocUnsafe` for fully static models; for variable-length fields it precomputes size then allocates once (no `concat`)
 * Added [`examples/codegen.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/codegen.ts) and README section [Compiled functions](#compiled-functions-codegen)
 * Added `npm run bench` and [`doc/BENCHMARKS.md`](doc/BENCHMARKS.md) with sample throughput (interpreter vs codegen)
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Works on `CStructBE` and `CStructLE`. For precompiled models: `CStructLE.fromCom
 
 **Security note:** `compile*` uses `new Function` with a model you provide. Use only **trusted** models (your own source or build-time artifacts), not untrusted user input.
 
-See [`examples/codegen.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/codegen.ts).
+See [`examples/codegen.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/codegen.ts). Sample throughput on MacBook M4 Pro: [`doc/BENCHMARKS.md`](https://github.com/MrHIDEn/cstruct/blob/main/doc/BENCHMARKS.md). Run `npm run bench` locally.
 
 ### Nested types and AtomTypes
 
@@ -924,6 +924,7 @@ Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/
 * Instance methods `cStruct.compileRead()` / `compileWrite()` / `compileMake()` use cached `parsedModel`
 * `compileMake` uses single `allocUnsafe` for fully static models and `chunks + concat` for variable-length fields
 * Added [`examples/codegen.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/codegen.ts) and README section [Compiled functions](#compiled-functions-codegen)
+* Added `npm run bench` and [`doc/BENCHMARKS.md`](doc/BENCHMARKS.md) with sample throughput (interpreter vs codegen)
 
 ### What's new in 1.6.2
 * Modernized dev stack: ESLint 9 (flat config), typescript-eslint 8, TypeScript 5.9, @types/node 20

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ If you only need to pack a plain object into a buffer — **Basic usage** is eno
 - [Basic usage](#basic-usage-objects--strings)
   - [Endianness (BE vs LE)](#endianness-be-vs-le)
   - [Precompiled models (`fromCompiled`)](#precompiled-models-fromcompiled)
+  - [Compiled functions (codegen)](#compiled-functions-codegen)
   - [Write into an existing buffer](#write-into-an-existing-buffer)
   - [Binary buffer field (`bufN`)](#binary-buffer-field-bufn)
   - [Wide string (`wstring` / `wsN`)](#wide-string-wstring--wsn)
@@ -154,6 +155,41 @@ console.log(cStruct.read(buffer).struct);
 `fromCompiled` accepts a JSON string or a parsed object/array (the same shape as `jsonModel`). See [`examples/from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts).
 
 **Security note:** Treat `jsonModel` as a **trusted build-time artifact** (same trust level as your own source code). `fromCompiled` only checks that the input is valid JSON (object or array) — it does **not** re-run `ModelParser` and does **not** limit size or nesting depth. Do not load `jsonModel` from untrusted sources (user upload, arbitrary URL, unverified remote config): a malicious payload can cause high memory/CPU use (`JSON.parse` on a huge or deeply nested document). Prefer compiling with `fromModelTypes` in your build and shipping the resulting string as a constant or a file you control.
+
+### Compiled functions (codegen)
+
+For hot loops (thousands of buffers per second), compile the model once into specialized functions via `new Function`. The result matches `read` / `write` / `make`, but skips walking the model tree on every call.
+
+```typescript
+import { CStructLE } from '@mrhiden/cstruct';
+
+const model = { x: 'u16', y: 'i32', flag: 'b8' };
+
+// Compile once at startup
+const readFrame  = CStructLE.compileRead(model);
+const writeFrame = CStructLE.compileWrite(model);
+const makeFrame  = CStructLE.compileMake(model);
+
+// Use many times
+const buf = makeFrame({ x: 13, y: -7, flag: true }).buffer;
+const { struct } = readFrame(buf, 0);
+writeFrame({ x: 1, y: 2, flag: false }, buf, 0);
+```
+
+Instance methods compile from the cached `parsedModel` (no second `parseModel`):
+
+```typescript
+const cStruct = CStructLE.fromModelTypes(model);
+const readFn = cStruct.compileRead();
+```
+
+Works on `CStructBE` and `CStructLE`. For precompiled models: `CStructLE.fromCompiled(jsonModel).compileRead()`.
+
+**When to use:** high-throughput parsing/serialization with a fixed model. **When not to:** occasional calls — regular `read`/`make` is simpler.
+
+**Security note:** `compile*` uses `new Function` with a model you provide. Use only **trusted** models (your own source or build-time artifacts), not untrusted user input.
+
+See [`examples/codegen.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/codegen.ts).
 
 ### Nested types and AtomTypes
 
@@ -869,6 +905,7 @@ Runnable scripts live in [`/examples`](https://github.com/MrHIDEn/cstruct/tree/m
 | [`simple-model.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/simple-model.ts) | Basic make/read, offset, write |
 | [`little-endian.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/little-endian.ts) | BE vs LE side-by-side |
 | [`from-compiled.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/from-compiled.ts) | Precompiled `jsonModel` / `fromCompiled` |
+| [`codegen.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/codegen.ts) | Compiled functions (`compileRead` / `compileWrite` / `compileMake`) |
 | [`write-offset.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/write-offset.ts) | `make` vs `write` with offset |
 | [`with-buffer.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/with-buffer.ts) | `bufN` binary fields |
 | [`wstring.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/wstring.ts) | UTF-16LE wide strings |
@@ -881,6 +918,12 @@ Runnable scripts live in [`/examples`](https://github.com/MrHIDEn/cstruct/tree/m
 Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/examples/README.md).
 
 ## Changelog
+
+### What's new in 1.7.0
+* Added `compileRead`, `compileWrite`, `compileMake` on `CStructBE` and `CStructLE` — compile a model once into specialized functions for high-throughput read/write/make
+* Instance methods `cStruct.compileRead()` / `compileWrite()` / `compileMake()` use cached `parsedModel`
+* `compileMake` uses single `allocUnsafe` for fully static models and `chunks + concat` for variable-length fields
+* Added [`examples/codegen.ts`](https://github.com/MrHIDEn/cstruct/blob/main/examples/codegen.ts) and README section [Compiled functions](#compiled-functions-codegen)
 
 ### What's new in 1.6.2
 * Modernized dev stack: ESLint 9 (flat config), typescript-eslint 8, TypeScript 5.9, @types/node 20

--- a/benchmarks/codegen-bench.ts
+++ b/benchmarks/codegen-bench.ts
@@ -1,0 +1,151 @@
+import { performance } from 'perf_hooks';
+import { CStructLE } from '../src';
+
+/**
+ * Zero-dependency micro-benchmark comparing the interpreter path
+ * (read/write/make) against the codegen path (compileRead/Write/Make).
+ *
+ * Run: npm run bench
+ */
+
+interface BenchResult {
+    name: string;
+    opsPerSec: number;
+    nsPerOp: number;
+}
+
+const DEFAULT_MS = Number(process.env.BENCH_MS ?? 700);
+const WARMUP_MS = 150;
+
+function runFor(fn: () => void, durationMs: number): { ops: number; elapsedMs: number } {
+    let ops = 0;
+    const start = performance.now();
+    let now = start;
+    // Batch to reduce clock-read overhead.
+    do {
+        for (let i = 0; i < 1000; i++) fn();
+        ops += 1000;
+        now = performance.now();
+    } while (now - start < durationMs);
+    return { ops, elapsedMs: now - start };
+}
+
+function bench(name: string, fn: () => void): BenchResult {
+    runFor(fn, WARMUP_MS); // warmup (JIT)
+    const { ops, elapsedMs } = runFor(fn, DEFAULT_MS);
+    const opsPerSec = (ops / elapsedMs) * 1000;
+    const nsPerOp = (elapsedMs * 1e6) / ops;
+    return { name, opsPerSec, nsPerOp };
+}
+
+function fmt(n: number): string {
+    return n.toLocaleString('en-US', { maximumFractionDigits: 0 });
+}
+
+function printGroup(title: string, results: BenchResult[]) {
+    console.log(`\n${title}`);
+    console.log('-'.repeat(title.length));
+    const baseline = results[0].opsPerSec;
+    for (const r of results) {
+        const speedup = (r.opsPerSec / baseline).toFixed(2);
+        const opsStr = `${fmt(r.opsPerSec)} ops/s`.padStart(20);
+        const nsStr = `${r.nsPerOp.toFixed(1)} ns/op`.padStart(14);
+        console.log(`  ${r.name.padEnd(26)} ${opsStr} ${nsStr}  x${speedup}`);
+    }
+}
+
+// --- Static model (fixed size) ---
+{
+    const model = { x: 'u16', y: 'i32', z: 'u32', flag: 'b8', d: 'd' };
+    const data = { x: 0x1234, y: -7, z: 42, flag: true, d: 123.456 };
+
+    const cStruct = CStructLE.fromModelTypes(model);
+    const buffer = cStruct.make(data).buffer;
+
+    const makeFn = cStruct.compileMake();
+    const readFn = cStruct.compileRead();
+    const writeFn = cStruct.compileWrite();
+    const writeTarget = Buffer.alloc(buffer.length);
+
+    printGroup('Static model — make (hot path)', [
+        bench('interpreter make()', () => { cStruct.make(data); }),
+        bench('makeFn() pre-compiled', () => { makeFn(data); }),
+    ]);
+
+    printGroup('Static model — read (hot path)', [
+        bench('interpreter read()', () => { cStruct.read(buffer); }),
+        bench('readFn() pre-compiled', () => { readFn(buffer, 0); }),
+    ]);
+
+    printGroup('Static model — write (hot path)', [
+        bench('interpreter write()', () => { cStruct.write(writeTarget, data); }),
+        bench('writeFn() pre-compiled', () => { writeFn(data, writeTarget, 0); }),
+    ]);
+}
+
+// --- Dynamic model (variable length) ---
+{
+    const model = { name: 's[i16]', items: 'u32[i16]' };
+    const data = { name: 'sensor-01', items: [1, 2, 3, 4, 5, 6, 7, 8] };
+
+    const cStruct = CStructLE.fromModelTypes(model);
+    const buffer = cStruct.make(data).buffer;
+
+    const makeFn = cStruct.compileMake();
+    const readFn = cStruct.compileRead();
+
+    printGroup('Dynamic model — make (hot path)', [
+        bench('interpreter make()', () => { cStruct.make(data); }),
+        bench('makeFn() pre-compiled', () => { makeFn(data); }),
+    ]);
+
+    printGroup('Dynamic model — read (hot path)', [
+        bench('interpreter read()', () => { cStruct.read(buffer); }),
+        bench('readFn() pre-compiled', () => { readFn(buffer, 0); }),
+    ]);
+}
+
+// --- Codegen compilation cost (re-compile every call — not recommended) ---
+{
+    const model = { x: 'u16', y: 'i32', z: 'u32', flag: 'b8', d: 'd' };
+    const cStruct = CStructLE.fromModelTypes(model);
+
+    printGroup('Codegen compilation (per call)', [
+        bench('cStruct.compileRead()', () => { cStruct.compileRead(); }),
+        bench('cStruct.compileWrite()', () => { cStruct.compileWrite(); }),
+        bench('cStruct.compileMake()', () => { cStruct.compileMake(); }),
+        bench('CStructLE.compileRead(model)', () => { CStructLE.compileRead(model); }),
+    ]);
+}
+
+// --- Cold start: instance + compile once ---
+{
+    const model = { x: 'u16', y: 'i32', z: 'u32', flag: 'b8', d: 'd' };
+    const jsonModel = CStructLE.fromModelTypes(model).jsonModel;
+
+    printGroup('Cold start (instance + compileRead once)', [
+        bench('fromModelTypes + compileRead', () => {
+            CStructLE.fromModelTypes(model).compileRead();
+        }),
+        bench('fromCompiled + compileRead', () => {
+            CStructLE.fromCompiled(jsonModel).compileRead();
+        }),
+        bench('static compileRead(model)', () => {
+            CStructLE.compileRead(model);
+        }),
+    ]);
+}
+
+// --- Construction cost (instance only, no codegen) ---
+{
+    const model = { x: 'u16', y: 'i32', z: 'u32', flag: 'b8', d: 'd' };
+    const jsonModel = CStructLE.fromModelTypes(model).jsonModel;
+
+    printGroup('Construction (instance only)', [
+        bench('fromModelTypes (parse)', () => { CStructLE.fromModelTypes(model); }),
+        bench('fromCompiled (no parse)', () => { CStructLE.fromCompiled(jsonModel); }),
+    ]);
+}
+
+console.log('\nNote: hot-path rows measure pre-compiled *Fn() only; compile* cost is in separate sections.');
+console.log('Results vary by machine and Node version. Higher ops/s is better.');

--- a/doc/BENCHMARKS.md
+++ b/doc/BENCHMARKS.md
@@ -59,11 +59,11 @@ Compares **end methods only** — `readFn(buf, 0)` vs `cStruct.read(buf)`:
 
 ## Dynamic model (hot path)
 
-Model: `{ name: 's[i16]', items: 'u32[i16]' }` — variable length; `compileMake` uses **chunks + `Buffer.concat`**.
+Model: `{ name: 's[i16]', items: 'u32[i16]' }` — variable length; `compileMake` computes size first, then single `allocUnsafe` (no `concat`).
 
 | Operation | Interpreter | Pre-compiled `*Fn()` | Speedup |
 |-----------|-------------|----------------------|---------|
-| **make** | 175k ops/s (5.7 µs/op) | 971k ops/s (1.0 µs/op) | **~5.5×** |
+| **make** | 182k ops/s (5.5 µs/op) | 7.38M ops/s (136 ns/op) | **~41×** |
 | **read** | 182k ops/s (5.5 µs/op) | 7.64M ops/s (131 ns/op) | **~42×** |
 
 Dynamic fields add loops and concatenation, so gains are smaller than for fully static models — but codegen remains significantly faster.

--- a/doc/BENCHMARKS.md
+++ b/doc/BENCHMARKS.md
@@ -1,0 +1,123 @@
+# Performance benchmarks
+
+Micro-benchmarks comparing the **interpreter** path (`read` / `write` / `make`) with the **codegen** path (`compileRead` / `compileWrite` / `compileMake`).
+
+Run locally:
+
+```bash
+npm run bench
+```
+
+Optional longer run:
+
+```bash
+BENCH_MS=2000 npm run bench
+```
+
+Source: [`benchmarks/codegen-bench.ts`](../benchmarks/codegen-bench.ts)
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| Machine | MacBook **M4 Pro** |
+| OS | macOS 26.5.1 |
+| Node.js | v26.4.0 |
+| Library | `@mrhiden/cstruct` 1.7.0 |
+| Endian | Little-endian (`CStructLE`) |
+| Bench duration | ~700 ms per case (default `BENCH_MS`) |
+
+Results are **indicative only**. Absolute numbers vary by CPU load, Node version, and model shape. Relative speedups between interpreter and codegen on the same machine are more meaningful than cross-machine comparisons.
+
+## Methodology
+
+Benchmarks are split into **separate sections** so costs are not mixed:
+
+| Section | What is measured |
+|---------|------------------|
+| **Hot path** | Pre-compiled `readFn()` / `writeFn()` / `makeFn()` vs interpreter `read()` / `write()` / `make()`. `compile*` is called **once before** the timed loop — compilation cost is **not** included. |
+| **Codegen compilation** | `cStruct.compileRead()` (and siblings) called **every iteration** — cost of `generate*Body` + `new Function`. |
+| **Cold start** | Full one-shot setup: create instance + `compileRead()` once. |
+| **Construction** | `new CStructLE(...)` only — no codegen. |
+
+- Uses Node.js `perf_hooks` (`performance.now()`).
+- **Warmup** (~150 ms) before each measurement (JIT).
+- Operations are batched in groups of 1000 to reduce timer overhead.
+- Correctness is covered separately by `tests/codegen.test.ts` (parity with the interpreter).
+
+## Static model (hot path)
+
+Model: `{ x: 'u16', y: 'i32', z: 'u32', flag: 'b8', d: 'd' }` — fixed size, single `allocUnsafe` in `compileMake`.
+
+Compares **end methods only** — `readFn(buf, 0)` vs `cStruct.read(buf)`:
+
+| Operation | Interpreter | Pre-compiled `*Fn()` | Speedup |
+|-----------|-------------|----------------------|---------|
+| **make** | 191k ops/s (5.2 µs/op) | 24.2M ops/s (41 ns/op) | **~127×** |
+| **read** | 184k ops/s (5.4 µs/op) | 52.8M ops/s (19 ns/op) | **~287×** |
+| **write** | 188k ops/s (5.3 µs/op) | 57.6M ops/s (17 ns/op) | **~307×** |
+
+## Dynamic model (hot path)
+
+Model: `{ name: 's[i16]', items: 'u32[i16]' }` — variable length; `compileMake` uses **chunks + `Buffer.concat`**.
+
+| Operation | Interpreter | Pre-compiled `*Fn()` | Speedup |
+|-----------|-------------|----------------------|---------|
+| **make** | 175k ops/s (5.7 µs/op) | 971k ops/s (1.0 µs/op) | **~5.5×** |
+| **read** | 182k ops/s (5.5 µs/op) | 7.64M ops/s (131 ns/op) | **~42×** |
+
+Dynamic fields add loops and concatenation, so gains are smaller than for fully static models — but codegen remains significantly faster.
+
+## Codegen compilation cost (per call)
+
+Re-running `compile*` on every iteration (anti-pattern — compile once at startup):
+
+| Call | Throughput | Notes |
+|------|------------|-------|
+| `cStruct.compileRead()` | 678k ops/s (~1.5 µs) | Instance already has `parsedModel`; only `generate` + `new Function` |
+| `cStruct.compileWrite()` | 716k ops/s (~1.4 µs) | Similar |
+| `cStruct.compileMake()` | 478k ops/s (~2.1 µs) | Also runs `analyzeModel` |
+| `CStructLE.compileRead(model)` | 188k ops/s (~5.3 µs) | **Plus** `ModelParser.parseModel` every time |
+
+`compileRead()` on an existing instance is **~3× faster** than `static compileRead(model)` because parsing is skipped. Still ~**300× slower** than calling a pre-compiled `readFn()` in a hot loop.
+
+## Cold start (instance + compileRead once)
+
+One-shot setup cost when the app starts:
+
+| Approach | Throughput | vs `fromModelTypes + compileRead` |
+|----------|------------|-----------------------------------|
+| `fromModelTypes` + `compileRead()` | 188k ops/s | baseline |
+| `fromCompiled` + `compileRead()` | 436k ops/s | **~2.3×** faster |
+| `CStructLE.compileRead(model)` | 187k ops/s | ~same as baseline (parses model each time) |
+
+Cold start is dominated by `new Function` (~1.5 µs) plus instance construction. `fromCompiled` wins by skipping `ModelParser`, not by speeding up codegen itself.
+
+## Construction (instance only, no codegen)
+
+| Approach | Throughput | Notes |
+|----------|------------|-------|
+| `fromModelTypes` (runs `ModelParser`) | 276k ops/s | Parses model every time |
+| `fromCompiled` (loads `jsonModel`) | 1.45M ops/s | **~5×** faster; skips parser |
+
+Use `fromCompiled` and compile codegen functions once at startup when you have many struct definitions or care about cold start.
+
+## When codegen is worth it
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Thousands of buffers per second, fixed model | **codegen** (`compileRead` / `compileWrite` / `compileMake`) |
+| Rare serialization, prototyping | **interpreter** (`read` / `write` / `make`) — simpler API |
+| Many struct definitions at startup | **`fromCompiled`** + instance `compileRead()` |
+| Untrusted model strings | **Neither codegen nor `fromCompiled`** — trusted models only |
+
+## Reproduce on your machine
+
+```bash
+git clone https://github.com/MrHIDEn/cstruct.git
+cd cstruct
+npm install
+npm run bench
+```
+
+Paste your output into an issue or PR if you want to extend this table for other hardware.

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,7 @@ Runnable scripts in this folder. Build first (`npm run build`), then run with `n
 | [`string-model-types.ts`](./string-model-types.ts) | String models + named types |
 | [`little-endian.ts`](./little-endian.ts) | BE vs LE side-by-side |
 | [`from-compiled.ts`](./from-compiled.ts) | Precompiled `jsonModel` / `fromCompiled` |
+| [`codegen.ts`](./codegen.ts) | Compiled functions (`compileRead` / `compileWrite` / `compileMake`) |
 | [`write-offset.ts`](./write-offset.ts) | `make` vs `write` with offset |
 | [`with-buffer.ts`](./with-buffer.ts) | `bufN` / binary buffer fields |
 | [`wstring.ts`](./wstring.ts) | `wsN` / UTF-16LE wide strings |

--- a/examples/codegen.ts
+++ b/examples/codegen.ts
@@ -1,0 +1,30 @@
+import { CStructBE, CStructLE } from '../src';
+
+const model = { x: 'u16', y: 'i32', flag: 'b8' };
+const data = { x: 13, y: -7, flag: true };
+
+// --- Static compile (parse model once) ---
+const readFrameBe = CStructBE.compileRead(model);
+const makeFrameBe = CStructBE.compileMake(model);
+
+const { buffer } = makeFrameBe(data);
+const readResult = readFrameBe(buffer);
+
+console.log('BE compileRead:', readResult.struct);
+// { x: 13, y: -7, flag: true }
+
+// --- Instance compile (uses cached parsedModel) ---
+const cStructLe = CStructLE.fromModelTypes(model);
+const readFrameLe = cStructLe.compileRead();
+const writeFrameLe = cStructLe.compileWrite();
+
+const leBuffer = cStructLe.make(data).buffer;
+const writeTarget = Buffer.alloc(leBuffer.length);
+writeFrameLe(data, writeTarget, 0);
+
+console.log('LE compileWrite hex:', writeTarget.toString('hex'));
+console.log('LE parity:', JSON.stringify(readFrameLe(leBuffer).struct) === JSON.stringify(data));
+
+// --- With fromCompiled ---
+const fromCompiled = CStructBE.fromCompiled(cStructLe.jsonModel);
+console.log('fromCompiled + compileRead:', fromCompiled.compileRead()(buffer).struct);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "scripts": {
     "sandbox": "ts-node-dev --transpile-only ./examples/sandbox.ts",
+    "bench": "ts-node --transpile-only ./benchmarks/codegen-bench.ts",
     "model-parser": "ts-node-dev --transpile-only ./src/model-parser.ts",
     "prepublish": "tsc",
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "For packing and unpacking bytes (C like structures) in/from Buffer based on Object/Array type for parsing.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/codegen/atom-spec.ts
+++ b/src/codegen/atom-spec.ts
@@ -1,0 +1,145 @@
+import { Endian } from './types';
+
+export interface AtomSpec {
+    size: number;
+    readExpr: (offset: string) => string;
+    writeExpr: (bufVar: string, offset: string, value: string) => string;
+}
+
+const E = (endian: Endian) => endian === 'le' ? 'LE' : 'BE';
+
+const ATOM_SIZES: Record<string, number> = {
+    b8: 1, u8: 1, i8: 1,
+    b16: 2, u16: 2, i16: 2,
+    b32: 4, u32: 4, i32: 4, f: 4,
+    b64: 8, u64: 8, i64: 8, d: 8,
+};
+
+const TYPE_ALIASES: Record<string, string> = {
+    B8: 'b8', BOOL8: 'b8', BOOL: 'b8', bool8: 'b8', bool: 'b8',
+    B16: 'b16', bool16: 'b16',
+    B32: 'b32', bool32: 'b32',
+    B64: 'b64', bool64: 'b64',
+    U8: 'u8', BYTE: 'u8', uint8: 'u8', uint8_t: 'u8',
+    U16: 'u16', WORD: 'u16', uint16: 'u16', uint16_t: 'u16',
+    U32: 'u32', DWORD: 'u32', uint32: 'u32', uint32_t: 'u32',
+    U64: 'u64', QWORD: 'u64', LWORD: 'u64', uint64: 'u64', uint64_t: 'u64',
+    I8: 'i8', SINT: 'i8', int8: 'i8', int8_t: 'i8', CHAR: 'i8',
+    I16: 'i16', INT: 'i16', int16: 'i16', int16_t: 'i16',
+    I32: 'i32', DINT: 'i32', int32: 'i32', int32_t: 'i32',
+    I64: 'i64', QINT: 'i64', LINT: 'i64', int64: 'i64', int64_t: 'i64',
+    F: 'f', F32: 'f', REAL: 'f', float: 'f', float32: 'f', float32_t: 'f', single: 'f', f32: 'f',
+    D: 'd', F64: 'd', LREAL: 'd', double: 'd', float64: 'd', float64_t: 'd', f64: 'd',
+};
+
+export function resolveAtomType(type: string): string {
+    return TYPE_ALIASES[type] ?? type;
+}
+
+export function getAtomSize(type: string): number | undefined {
+    return ATOM_SIZES[resolveAtomType(type)];
+}
+
+export function getAtomSpec(type: string, endian: Endian): AtomSpec | undefined {
+    type = resolveAtomType(type);
+    const size = ATOM_SIZES[type];
+    if (!size) return undefined;
+    const EDN = E(endian);
+
+    switch (type) {
+        case 'b8':
+            return {
+                size,
+                readExpr: (o) => `Boolean(buf.readInt8(${o}))`,
+                writeExpr: (b, o, v) => `${b}.writeInt8(${v} ? 1 : 0, ${o})`,
+            };
+        case 'u8':
+            return {
+                size,
+                readExpr: (o) => `buf.readUInt8(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeUInt8(${v}, ${o})`,
+            };
+        case 'i8':
+            return {
+                size,
+                readExpr: (o) => `buf.readInt8(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeInt8(${v}, ${o})`,
+            };
+        case 'b16':
+            return {
+                size,
+                readExpr: (o) => `Boolean(buf.readInt16${EDN}(${o}))`,
+                writeExpr: (b, o, v) => `${b}.writeInt16${EDN}(${v} ? 1 : 0, ${o})`,
+            };
+        case 'u16':
+            return {
+                size,
+                readExpr: (o) => `buf.readUInt16${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeUInt16${EDN}(${v}, ${o})`,
+            };
+        case 'i16':
+            return {
+                size,
+                readExpr: (o) => `buf.readInt16${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeInt16${EDN}(${v}, ${o})`,
+            };
+        case 'b32':
+            return {
+                size,
+                readExpr: (o) => `Boolean(buf.readInt32${EDN}(${o}))`,
+                writeExpr: (b, o, v) => `${b}.writeInt32${EDN}(${v} ? 1 : 0, ${o})`,
+            };
+        case 'u32':
+            return {
+                size,
+                readExpr: (o) => `buf.readUInt32${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeUInt32${EDN}(${v}, ${o})`,
+            };
+        case 'i32':
+            return {
+                size,
+                readExpr: (o) => `buf.readInt32${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeInt32${EDN}(${v}, ${o})`,
+            };
+        case 'f':
+            return {
+                size,
+                readExpr: (o) => `buf.readFloat${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeFloat${EDN}(${v}, ${o})`,
+            };
+        case 'b64':
+            return {
+                size,
+                readExpr: (o) => `Boolean(buf.readBigInt64${EDN}(${o}))`,
+                writeExpr: (b, o, v) => `${b}.writeBigInt64${EDN}(BigInt(${v}), ${o})`,
+            };
+        case 'u64':
+            return {
+                size,
+                readExpr: (o) => `buf.readBigUInt64${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeBigUInt64${EDN}(BigInt(${v}), ${o})`,
+            };
+        case 'i64':
+            return {
+                size,
+                readExpr: (o) => `buf.readBigInt64${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeBigInt64${EDN}(BigInt(${v}), ${o})`,
+            };
+        case 'd':
+            return {
+                size,
+                readExpr: (o) => `buf.readDouble${EDN}(${o})`,
+                writeExpr: (b, o, v) => `${b}.writeDouble${EDN}(${v}, ${o})`,
+            };
+        default:
+            return undefined;
+    }
+}
+
+export function getLengthPrefixSpec(lengthType: string, endian: Endian): AtomSpec {
+    const spec = getAtomSpec(lengthType, endian);
+    if (!spec) {
+        throw new Error(`Unsupported dynamic length type "${lengthType}".`);
+    }
+    return spec;
+}

--- a/src/codegen/compile.ts
+++ b/src/codegen/compile.ts
@@ -1,0 +1,55 @@
+import { Model, Types } from '../types';
+import { ModelParser } from '../model-parser';
+import { analyzeModel } from './model-analyzer';
+import { generateMakeBody, generateReadBody, generateWriteBody } from './generate';
+import {
+    CompiledMakeFn,
+    CompiledReadFn,
+    CompiledWriteFn,
+    Endian,
+} from './types';
+
+function parseModel(model: Model, types?: Types): Model {
+    const json = ModelParser.parseModel(model, types);
+    return JSON.parse(json) as Model;
+}
+
+function compileReadFromParsed<T>(parsed: Model, endian: Endian): CompiledReadFn<T> {
+    const body = generateReadBody(parsed, endian);
+    return new Function('buf', 'off', body) as CompiledReadFn<T>;
+}
+
+function compileWriteFromParsed<T>(parsed: Model, endian: Endian): CompiledWriteFn<T> {
+    const body = generateWriteBody(parsed, endian);
+    return new Function('struct', 'buf', 'off', body) as CompiledWriteFn<T>;
+}
+
+function compileMakeFromParsed<T>(parsed: Model, endian: Endian): CompiledMakeFn<T> {
+    const analysis = analyzeModel(parsed);
+    const body = generateMakeBody(parsed, endian, analysis.hasVariableLength, analysis.staticSize);
+    return new Function('struct', body) as CompiledMakeFn<T>;
+}
+
+export function compileRead<T = unknown>(model: Model, types: Types | undefined, endian: Endian): CompiledReadFn<T> {
+    return compileReadFromParsed<T>(parseModel(model, types), endian);
+}
+
+export function compileWrite<T = unknown>(model: Model, types: Types | undefined, endian: Endian): CompiledWriteFn<T> {
+    return compileWriteFromParsed<T>(parseModel(model, types), endian);
+}
+
+export function compileMake<T = unknown>(model: Model, types: Types | undefined, endian: Endian): CompiledMakeFn<T> {
+    return compileMakeFromParsed<T>(parseModel(model, types), endian);
+}
+
+export function compileReadFromParsedModel<T = unknown>(parsed: Model, endian: Endian): CompiledReadFn<T> {
+    return compileReadFromParsed<T>(parsed, endian);
+}
+
+export function compileWriteFromParsedModel<T = unknown>(parsed: Model, endian: Endian): CompiledWriteFn<T> {
+    return compileWriteFromParsed<T>(parsed, endian);
+}
+
+export function compileMakeFromParsedModel<T = unknown>(parsed: Model, endian: Endian): CompiledMakeFn<T> {
+    return compileMakeFromParsed<T>(parsed, endian);
+}

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -25,7 +25,9 @@ function readLength(ctx: CodegenContext, lengthType: string, offsetVar: string):
 
 function writeLength(ctx: CodegenContext, lengthType: string, offsetVar: string, value: string) {
     const spec = getLengthPrefixSpec(lengthType, ctx.endian);
-    if (ctx.mode === 'make' && ctx.useChunks) {
+    if (ctx.accumulateSize) {
+        push(ctx, `size += ${spec.size};`);
+    } else if (isChunkMake(ctx)) {
         const b = tmpId(ctx);
         push(ctx, `{ const ${b} = Buffer.allocUnsafe(${spec.size}); ${spec.writeExpr(b, '0', value)}; chunks.push(${b}); }`);
     } else {
@@ -56,7 +58,15 @@ function readBuffer(ctx: CodegenContext, offsetVar: string, sizeExpr: string, ta
 }
 
 function writeStringUtf8(ctx: CodegenContext, offsetVar: string, valueExpr: string, size: number | string, trailing = false, dynamic = false) {
-    if (ctx.mode === 'make' && ctx.useChunks) {
+    if (ctx.accumulateSize) {
+        if (trailing) {
+            push(ctx, `size += Buffer.byteLength(${valueExpr}, 'utf8') + 1;`);
+        } else if (dynamic) {
+            push(ctx, `size += Buffer.byteLength(${valueExpr}, 'utf8');`);
+        } else {
+            push(ctx, `size += ${size};`);
+        }
+    } else if (isChunkMake(ctx)) {
         if (trailing) {
             const b = tmpId(ctx);
             push(ctx, `{ const ${b} = Buffer.alloc(Buffer.byteLength(${valueExpr}, 'utf8') + 1); ${b}.write(${valueExpr}, 0, 'utf8'); chunks.push(${b}); }`);
@@ -80,7 +90,13 @@ function writeStringUtf8(ctx: CodegenContext, offsetVar: string, valueExpr: stri
 
 function writeWString(ctx: CodegenContext, offsetVar: string, valueExpr: string, size: number | string, trailing = false) {
     const byteSize = typeof size === 'number' ? size * 2 : `(${size}) * 2`;
-    if (ctx.mode === 'make' && ctx.useChunks) {
+    if (ctx.accumulateSize) {
+        if (trailing) {
+            push(ctx, `size += (${valueExpr}).length * 2 + 2;`);
+        } else {
+            push(ctx, `size += ${byteSize};`);
+        }
+    } else if (isChunkMake(ctx)) {
         if (trailing) {
             const b = tmpId(ctx);
             push(ctx, `{ const ${b} = Buffer.alloc((${valueExpr}).length * 2 + 2); ${b}.write(${valueExpr}, 0, 'utf16le'); chunks.push(${b}); }`);
@@ -99,7 +115,9 @@ function writeWString(ctx: CodegenContext, offsetVar: string, valueExpr: string,
 }
 
 function writeBufferField(ctx: CodegenContext, offsetVar: string, valueExpr: string, size: number) {
-    if (ctx.mode === 'make' && ctx.useChunks) {
+    if (ctx.accumulateSize) {
+        push(ctx, `size += ${size};`);
+    } else if (isChunkMake(ctx)) {
         const b = tmpId(ctx);
         push(ctx, `{ const ${b} = Buffer.alloc(${size}); ${valueExpr}.copy(${b}, 0, 0, ${size}); chunks.push(${b}); }`);
     } else {
@@ -110,7 +128,9 @@ function writeBufferField(ctx: CodegenContext, offsetVar: string, valueExpr: str
 function writeAtom(ctx: CodegenContext, type: string, offsetVar: string, valueExpr: string) {
     const spec = getAtomSpec(type, ctx.endian);
     if (!spec) throw new Error(`Unknown type ${type}`);
-    if (ctx.mode === 'make' && ctx.useChunks) {
+    if (ctx.accumulateSize) {
+        push(ctx, `size += ${spec.size};`);
+    } else if (isChunkMake(ctx)) {
         const b = tmpId(ctx);
         push(ctx, `{ const ${b} = Buffer.allocUnsafe(${spec.size}); ${spec.writeExpr(b, '0', valueExpr)}; chunks.push(${b}); }`);
     } else {
@@ -259,6 +279,14 @@ function writeArrayItems(
     structArrayExpr: string,
     offsetVar: string,
 ) {
+    if (ctx.accumulateSize && typeof itemsType === 'string') {
+        const spec = getAtomSpec(itemsType, ctx.endian);
+        if (spec) {
+            push(ctx, `size += ${structArrayExpr}.length * ${spec.size};`);
+            return;
+        }
+    }
+
     const i = tmpId(ctx);
     push(ctx, `for (let ${i} = 0; ${i} < ${structArrayExpr}.length; ${i}++) {`);
     if (typeof itemsType === 'object' && !Array.isArray(itemsType)) {
@@ -375,10 +403,13 @@ function writeDynamicOrStatic(
             if (isStatic && staticSize === 0) {
                 writeWString(ctx, offsetVar, structKeyExpr, 0, true);
             } else if (!isStatic) {
-                const b = tmpId(ctx);
-                if (ctx.mode === 'make' && ctx.useChunks) {
+                if (ctx.accumulateSize) {
+                    push(ctx, `size += (${structKeyExpr}).length * 2;`);
+                } else if (isChunkMake(ctx)) {
+                    const b = tmpId(ctx);
                     push(ctx, `{ const ${b} = Buffer.alloc((${structKeyExpr}).length * 2); ${b}.write(${structKeyExpr}, 0, 'utf16le'); chunks.push(${b}); }`);
                 } else {
+                    const b = tmpId(ctx);
                     push(ctx, `{ const ${b} = (${structKeyExpr}).length * 2; buf.write(${structKeyExpr}, ${offsetVar}, ${b}, 'utf16le'); ${offsetVar} += ${b}; }`);
                 }
             } else {
@@ -581,8 +612,12 @@ function generateWriteObject(ctx: CodegenContext, model: Model, offsetVar: strin
     }
 }
 
-function createContext(endian: Endian, mode: CodegenMode, useChunks: boolean): CodegenContext {
-    return { endian, mode, lines: [], counter: 0, useChunks };
+function createContext(endian: Endian, mode: CodegenMode, useChunks: boolean, accumulateSize = false): CodegenContext {
+    return { endian, mode, lines: [], counter: 0, useChunks, accumulateSize };
+}
+
+function isChunkMake(ctx: CodegenContext): boolean {
+    return ctx.mode === 'make' && ctx.useChunks && !ctx.accumulateSize;
 }
 
 export function generateReadBody(model: Model, endian: Endian): string {
@@ -618,18 +653,27 @@ export function generateWriteBody(model: Model, endian: Endian): string {
 }
 
 export function generateMakeBody(model: Model, endian: Endian, useChunks: boolean, staticSize: number): string {
-    const ctx = createContext(endian, 'make', useChunks);
     if (useChunks) {
-        push(ctx, 'const chunks = [];');
-        push(ctx, 'let o = 0;');
-        generateWriteObject(ctx, model, 'o', 'struct');
-        push(ctx, 'const buffer = Buffer.concat(chunks);');
-        push(ctx, 'return { buffer, offset: buffer.length, size: buffer.length };');
-    } else {
-        push(ctx, `const buf = Buffer.allocUnsafe(${staticSize});`);
-        push(ctx, 'let o = 0;');
-        generateWriteObject(ctx, model, 'o', 'struct');
-        push(ctx, 'return { buffer: buf, offset: o, size: o };');
+        const sizeCtx = createContext(endian, 'make', false, true);
+        push(sizeCtx, 'let size = 0;');
+        generateWriteObject(sizeCtx, model, 'o', 'struct');
+
+        const writeCtx = createContext(endian, 'make', false, false);
+        push(writeCtx, 'let o = 0;');
+        generateWriteObject(writeCtx, model, 'o', 'struct');
+
+        return [
+            ...sizeCtx.lines,
+            'const buf = Buffer.allocUnsafe(size);',
+            ...writeCtx.lines,
+            'return { buffer: buf, offset: o, size: o };',
+        ].join('\n');
     }
+
+    const ctx = createContext(endian, 'make', false);
+    push(ctx, `const buf = Buffer.allocUnsafe(${staticSize});`);
+    push(ctx, 'let o = 0;');
+    generateWriteObject(ctx, model, 'o', 'struct');
+    push(ctx, 'return { buffer: buf, offset: o, size: o };');
     return ctx.lines.join('\n');
 }

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -16,6 +16,31 @@ function push(ctx: CodegenContext, line: string) {
     ctx.lines.push(line);
 }
 
+function quotedKey(key: string): string {
+    return JSON.stringify(key);
+}
+
+function structProp(structExpr: string, key: string): string {
+    return `${structExpr}[${quotedKey(key)}]`;
+}
+
+function dynamicPayloadLengthExpr(
+    structKeyExpr: string,
+    valueExpr: string,
+    specialType: SpecialType | undefined,
+    isStatic: boolean,
+    staticSize: number,
+): string {
+    if (isStatic) return String(staticSize);
+    if (specialType === SpecialType.Json || specialType === SpecialType.String) {
+        return `(${valueExpr}).length`;
+    }
+    if (specialType === SpecialType.WString) {
+        return `(${structKeyExpr}).length`;
+    }
+    return `${structKeyExpr}.length`;
+}
+
 function readLength(ctx: CodegenContext, lengthType: string, offsetVar: string): string {
     const spec = getLengthPrefixSpec(lengthType, ctx.endian);
     const id = tmpId(ctx);
@@ -60,9 +85,9 @@ function readBuffer(ctx: CodegenContext, offsetVar: string, sizeExpr: string, ta
 function writeStringUtf8(ctx: CodegenContext, offsetVar: string, valueExpr: string, size: number | string, trailing = false, dynamic = false) {
     if (ctx.accumulateSize) {
         if (trailing) {
-            push(ctx, `size += Buffer.byteLength(${valueExpr}, 'utf8') + 1;`);
+            push(ctx, `size += (${valueExpr}).length + 1;`);
         } else if (dynamic) {
-            push(ctx, `size += Buffer.byteLength(${valueExpr}, 'utf8');`);
+            push(ctx, `size += (${valueExpr}).length;`);
         } else {
             push(ctx, `size += ${size};`);
         }
@@ -79,9 +104,9 @@ function writeStringUtf8(ctx: CodegenContext, offsetVar: string, valueExpr: stri
         }
     } else {
         if (trailing) {
-            push(ctx, `{ const _b = Buffer.byteLength(${valueExpr}, 'utf8'); buf.write(${valueExpr}, ${offsetVar}); buf.writeUInt8(0, ${offsetVar} + _b); ${offsetVar} += _b + 1; }`);
+            push(ctx, `{ const _b = (${valueExpr}).length; buf.write(${valueExpr}, ${offsetVar}); buf.writeUInt8(0, ${offsetVar} + _b); ${offsetVar} += _b + 1; }`);
         } else if (dynamic) {
-            push(ctx, `{ const _b = Buffer.byteLength(${valueExpr}, 'utf8'); buf.write(${valueExpr}, ${offsetVar}, _b, 'utf8'); ${offsetVar} += _b; }`);
+            push(ctx, `{ const _b = (${valueExpr}).length; buf.write(${valueExpr}, ${offsetVar}, _b, 'utf8'); ${offsetVar} += _b; }`);
         } else {
             push(ctx, `buf.fill(0, ${offsetVar}, ${offsetVar} + ${size}); buf.write(${valueExpr}, ${offsetVar}, ${size}, 'utf8'); ${offsetVar} += ${size};`);
         }
@@ -378,7 +403,7 @@ function writeDynamicOrStatic(
         push(ctx, `if (${structKeyExpr}.length > ${staticSize}) throw new Error('Size of value ' + ${structKeyExpr}.length + ' is greater than ${staticSize}.');`);
     }
 
-    const sizeExpr = isStatic ? String(staticSize) : `${structKeyExpr}.length`;
+    const sizeExpr = dynamicPayloadLengthExpr(structKeyExpr, valueExpr, specialType, isStatic, staticSize);
 
     if (+sizeExpr === 0 && specialType === SpecialType.Buffer) {
         throw new Error('Buffer size can not be 0.');
@@ -543,7 +568,7 @@ function generateReadObject(ctx: CodegenContext, model: Model, offsetVar: string
                 offsetVar,
                 val,
             );
-            push(ctx, `${target}.${dynamicType} = ${val};`);
+            push(ctx, `${structProp(target, dynamicType)} = ${val};`);
             continue;
         }
 
@@ -559,14 +584,14 @@ function generateReadObject(ctx: CodegenContext, model: Model, offsetVar: string
                     offsetVar,
                     val,
                 );
-                push(ctx, `${target}.${modelKey} = ${val};`);
+                push(ctx, `${structProp(target, modelKey)} = ${val};`);
                 continue;
             }
         }
 
         const val = tmpId(ctx);
         readField(ctx, modelType, offsetVar, val);
-        push(ctx, `${target}.${modelKey} = ${val};`);
+        push(ctx, `${structProp(target, modelKey)} = ${val};`);
     }
 }
 
@@ -586,7 +611,7 @@ function generateWriteObject(ctx: CodegenContext, model: Model, offsetVar: strin
                 ctx,
                 modelType as string,
                 dynamicLength,
-                `${structExpr}.${dynamicType}`,
+                structProp(structExpr, dynamicType),
                 modelType as string,
                 offsetVar,
             );
@@ -600,7 +625,7 @@ function generateWriteObject(ctx: CodegenContext, model: Model, offsetVar: strin
                     ctx,
                     typeGroups.dynamicType,
                     typeGroups.dynamicLength,
-                    `${structExpr}.${modelKey}`,
+                    structProp(structExpr, modelKey),
                     typeGroups.dynamicType,
                     offsetVar,
                 );
@@ -608,7 +633,7 @@ function generateWriteObject(ctx: CodegenContext, model: Model, offsetVar: strin
             }
         }
 
-        writeField(ctx, modelType, offsetVar, `${structExpr}.${modelKey}`);
+        writeField(ctx, modelType, offsetVar, structProp(structExpr, modelKey));
     }
 }
 
@@ -638,18 +663,21 @@ export function generateReadBody(model: Model, endian: Endian): string {
 }
 
 export function generateWriteBody(model: Model, endian: Endian): string {
-    const ctx = createContext(endian, 'write', false);
-    push(ctx, 'off = off || 0;');
-    push(ctx, 'let o = off;');
-    if (Array.isArray(model)) {
-        generateWriteObject(ctx, model, 'o', 'struct');
-    } else {
-        generateWriteObject(ctx, model, 'o', 'struct');
-    }
-    push(ctx, 'const written = o - off;');
-    push(ctx, 'if (written > buf.length - off) throw new Error("Write buffer is too short. Needs " + (written - (buf.length - off)) + " byte/s more.");');
-    push(ctx, 'return { buffer: buf, offset: o, size: written };');
-    return ctx.lines.join('\n');
+    const sizeCtx = createContext(endian, 'write', false, true);
+    push(sizeCtx, 'let size = 0;');
+    generateWriteObject(sizeCtx, model, 'o', 'struct');
+
+    const writeCtx = createContext(endian, 'write', false, false);
+    push(writeCtx, 'let o = off;');
+    generateWriteObject(writeCtx, model, 'o', 'struct');
+
+    return [
+        'off = off || 0;',
+        ...sizeCtx.lines,
+        'if (size > buf.length - off) throw new Error("Write buffer is too short. Needs " + (size - (buf.length - off)) + " byte/s more.");',
+        ...writeCtx.lines,
+        'return { buffer: buf, offset: o, size: size };',
+    ].join('\n');
 }
 
 export function generateMakeBody(model: Model, endian: Endian, useChunks: boolean, staticSize: number): string {

--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -1,0 +1,635 @@
+import { Model, ModelValue, SpecialType, Type } from '../types';
+import { getAtomSpec, getLengthPrefixSpec } from './atom-spec';
+import {
+    extractTypeAndSize,
+    getDotGroups,
+    getSpecialType,
+    parseSizedAtom,
+} from './type-utils';
+import { CodegenContext, CodegenMode, Endian } from './types';
+
+function tmpId(ctx: CodegenContext): string {
+    return `_t${ctx.counter++}`;
+}
+
+function push(ctx: CodegenContext, line: string) {
+    ctx.lines.push(line);
+}
+
+function readLength(ctx: CodegenContext, lengthType: string, offsetVar: string): string {
+    const spec = getLengthPrefixSpec(lengthType, ctx.endian);
+    const id = tmpId(ctx);
+    push(ctx, `const ${id} = ${spec.readExpr(offsetVar)}; ${offsetVar} += ${spec.size};`);
+    return id;
+}
+
+function writeLength(ctx: CodegenContext, lengthType: string, offsetVar: string, value: string) {
+    const spec = getLengthPrefixSpec(lengthType, ctx.endian);
+    if (ctx.mode === 'make' && ctx.useChunks) {
+        const b = tmpId(ctx);
+        push(ctx, `{ const ${b} = Buffer.allocUnsafe(${spec.size}); ${spec.writeExpr(b, '0', value)}; chunks.push(${b}); }`);
+    } else {
+        push(ctx, `${spec.writeExpr('buf', offsetVar, value)}; ${offsetVar} += ${spec.size};`);
+    }
+}
+
+function readStringUtf8(ctx: CodegenContext, offsetVar: string, sizeExpr: string, target: string) {
+    push(ctx, `${target} = buf.toString('utf8', ${offsetVar}, ${offsetVar} + ${sizeExpr}).split('\\0')[0]; ${offsetVar} += ${sizeExpr};`);
+}
+
+function readStringUtf8Trailing(ctx: CodegenContext, offsetVar: string, target: string) {
+    const sz = tmpId(ctx);
+    push(ctx, `{ const ${sz} = buf.indexOf(0, ${offsetVar}) - ${offsetVar} + 1; ${target} = buf.toString('utf8', ${offsetVar}, ${offsetVar} + ${sz}).split('\\0')[0]; ${offsetVar} += ${sz}; }`);
+}
+
+function readWString(ctx: CodegenContext, offsetVar: string, sizeExpr: string, target: string) {
+    push(ctx, `${target} = buf.toString('utf16le', ${offsetVar}, ${offsetVar} + ${sizeExpr}).split('\\u0000')[0]; ${offsetVar} += ${sizeExpr};`);
+}
+
+function readWStringTrailing(ctx: CodegenContext, offsetVar: string, target: string) {
+    const sz = tmpId(ctx);
+    push(ctx, `{ const ${sz} = buf.indexOf('\\u0000', ${offsetVar}, 'utf16le') - ${offsetVar} + 2; ${target} = buf.toString('utf16le', ${offsetVar}, ${offsetVar} + ${sz}).split('\\u0000')[0]; ${offsetVar} += ${sz}; }`);
+}
+
+function readBuffer(ctx: CodegenContext, offsetVar: string, sizeExpr: string, target: string) {
+    push(ctx, `${target} = buf.slice(${offsetVar}, ${offsetVar} + ${sizeExpr}); ${offsetVar} += ${sizeExpr};`);
+}
+
+function writeStringUtf8(ctx: CodegenContext, offsetVar: string, valueExpr: string, size: number | string, trailing = false, dynamic = false) {
+    if (ctx.mode === 'make' && ctx.useChunks) {
+        if (trailing) {
+            const b = tmpId(ctx);
+            push(ctx, `{ const ${b} = Buffer.alloc(Buffer.byteLength(${valueExpr}, 'utf8') + 1); ${b}.write(${valueExpr}, 0, 'utf8'); chunks.push(${b}); }`);
+        } else if (dynamic) {
+            const b = tmpId(ctx);
+            push(ctx, `{ const ${b} = Buffer.alloc(Buffer.byteLength(${valueExpr}, 'utf8')); ${b}.write(${valueExpr}, 0, 'utf8'); chunks.push(${b}); }`);
+        } else {
+            const b = tmpId(ctx);
+            push(ctx, `{ const ${b} = Buffer.alloc(${size}); ${b}.write(${valueExpr}, 0, ${size}, 'utf8'); chunks.push(${b}); }`);
+        }
+    } else {
+        if (trailing) {
+            push(ctx, `{ const _b = Buffer.byteLength(${valueExpr}, 'utf8'); buf.write(${valueExpr}, ${offsetVar}); buf.writeUInt8(0, ${offsetVar} + _b); ${offsetVar} += _b + 1; }`);
+        } else if (dynamic) {
+            push(ctx, `{ const _b = Buffer.byteLength(${valueExpr}, 'utf8'); buf.write(${valueExpr}, ${offsetVar}, _b, 'utf8'); ${offsetVar} += _b; }`);
+        } else {
+            push(ctx, `buf.fill(0, ${offsetVar}, ${offsetVar} + ${size}); buf.write(${valueExpr}, ${offsetVar}, ${size}, 'utf8'); ${offsetVar} += ${size};`);
+        }
+    }
+}
+
+function writeWString(ctx: CodegenContext, offsetVar: string, valueExpr: string, size: number | string, trailing = false) {
+    const byteSize = typeof size === 'number' ? size * 2 : `(${size}) * 2`;
+    if (ctx.mode === 'make' && ctx.useChunks) {
+        if (trailing) {
+            const b = tmpId(ctx);
+            push(ctx, `{ const ${b} = Buffer.alloc((${valueExpr}).length * 2 + 2); ${b}.write(${valueExpr}, 0, 'utf16le'); chunks.push(${b}); }`);
+        } else {
+            const b = tmpId(ctx);
+            push(ctx, `{ const ${b} = Buffer.alloc(${byteSize}); ${b}.write(${valueExpr}, 0, ${byteSize}, 'utf16le'); chunks.push(${b}); }`);
+        }
+    } else {
+        if (trailing) {
+            const b = tmpId(ctx);
+            push(ctx, `{ const ${b} = (${valueExpr}).length * 2; buf.write(${valueExpr}, ${offsetVar}, ${b}, 'utf16le'); buf.writeUInt16LE(0, ${offsetVar} + ${b}); ${offsetVar} += ${b} + 2; }`);
+        } else {
+            push(ctx, `buf.fill(0, ${offsetVar}, ${offsetVar} + ${byteSize}); buf.write(${valueExpr}, ${offsetVar}, ${byteSize}, 'utf16le'); ${offsetVar} += ${byteSize};`);
+        }
+    }
+}
+
+function writeBufferField(ctx: CodegenContext, offsetVar: string, valueExpr: string, size: number) {
+    if (ctx.mode === 'make' && ctx.useChunks) {
+        const b = tmpId(ctx);
+        push(ctx, `{ const ${b} = Buffer.alloc(${size}); ${valueExpr}.copy(${b}, 0, 0, ${size}); chunks.push(${b}); }`);
+    } else {
+        push(ctx, `${valueExpr}.copy(buf, ${offsetVar}, 0, ${size}); ${offsetVar} += ${size};`);
+    }
+}
+
+function writeAtom(ctx: CodegenContext, type: string, offsetVar: string, valueExpr: string) {
+    const spec = getAtomSpec(type, ctx.endian);
+    if (!spec) throw new Error(`Unknown type ${type}`);
+    if (ctx.mode === 'make' && ctx.useChunks) {
+        const b = tmpId(ctx);
+        push(ctx, `{ const ${b} = Buffer.allocUnsafe(${spec.size}); ${spec.writeExpr(b, '0', valueExpr)}; chunks.push(${b}); }`);
+    } else {
+        push(ctx, `${spec.writeExpr('buf', offsetVar, valueExpr)}; ${offsetVar} += ${spec.size};`);
+    }
+}
+
+function readAtom(ctx: CodegenContext, type: string, offsetVar: string, target: string) {
+    const spec = getAtomSpec(type, ctx.endian);
+    if (!spec) throw new Error(`Unknown type ${type}`);
+    push(ctx, `${target} = ${spec.readExpr(offsetVar)}; ${offsetVar} += ${spec.size};`);
+}
+
+function readScalarType(ctx: CodegenContext, modelType: string, offsetVar: string, target: string) {
+    if (modelType === 'buf0') {
+        throw new Error('Buffer size can not be 0. (read)');
+    }
+
+    const atom = getAtomSpec(modelType, ctx.endian);
+    if (atom) {
+        readAtom(ctx, modelType, offsetVar, target);
+        return;
+    }
+
+    const sized = parseSizedAtom(modelType);
+    if (sized) {
+        const special = getSpecialType(sized.base);
+        if (special === SpecialType.String) {
+            if (sized.size === 0) {
+                readStringUtf8Trailing(ctx, offsetVar, target);
+            } else {
+                readStringUtf8(ctx, offsetVar, String(sized.size), target);
+            }
+            return;
+        }
+        if (special === SpecialType.WString) {
+            const bytes = sized.size * 2;
+            if (sized.size === 0) {
+                readWStringTrailing(ctx, offsetVar, target);
+            } else {
+                readWString(ctx, offsetVar, String(bytes), target);
+            }
+            return;
+        }
+        if (special === SpecialType.Buffer) {
+            readBuffer(ctx, offsetVar, String(sized.size), target);
+            return;
+        }
+        if (special === SpecialType.Json) {
+            if (sized.size === 0) {
+                readStringUtf8Trailing(ctx, offsetVar, target);
+                push(ctx, `${target} = JSON.parse(${target});`);
+            } else {
+                const raw = tmpId(ctx);
+                readStringUtf8(ctx, offsetVar, String(sized.size), raw);
+                push(ctx, `${target} = JSON.parse(${raw});`);
+            }
+            return;
+        }
+    }
+
+    if (modelType === 'j0') {
+        const raw = tmpId(ctx);
+        readStringUtf8Trailing(ctx, offsetVar, raw);
+        push(ctx, `${target} = JSON.parse(${raw});`);
+        return;
+    }
+
+    throw new TypeError(`Unknown type "${modelType}"`);
+}
+
+function writeScalarType(ctx: CodegenContext, modelType: string, offsetVar: string, valueExpr: string) {
+    if (modelType === 'buf0') {
+        throw new Error('Buffer size can not be 0. (make)');
+    }
+
+    const atom = getAtomSpec(modelType, ctx.endian);
+    if (atom) {
+        writeAtom(ctx, modelType, offsetVar, valueExpr);
+        return;
+    }
+
+    const sized = parseSizedAtom(modelType);
+    if (sized) {
+        const special = getSpecialType(sized.base);
+        if (special === SpecialType.String) {
+            writeStringUtf8(ctx, offsetVar, valueExpr, sized.size, sized.size === 0);
+            return;
+        }
+        if (special === SpecialType.WString) {
+            writeWString(ctx, offsetVar, valueExpr, sized.size, sized.size === 0);
+            return;
+        }
+        if (special === SpecialType.Buffer) {
+            writeBufferField(ctx, offsetVar, valueExpr, sized.size);
+            return;
+        }
+        if (special === SpecialType.Json) {
+            const jsonExpr = sized.size === 0 ? `JSON.stringify(${valueExpr})` : `JSON.stringify(${valueExpr})`;
+            writeStringUtf8(ctx, offsetVar, jsonExpr, sized.size, sized.size === 0);
+            return;
+        }
+    }
+
+    if (modelType === 'j0') {
+        writeStringUtf8(ctx, offsetVar, `JSON.stringify(${valueExpr})`, 0, true);
+        return;
+    }
+
+    throw new TypeError(`Unknown type "${modelType}"`);
+}
+
+function readArrayItems(
+    ctx: CodegenContext,
+    itemsType: Type,
+    sizeExpr: string,
+    offsetVar: string,
+    target: string,
+) {
+    push(ctx, `${target} = [];`);
+    const i = tmpId(ctx);
+    push(ctx, `for (let ${i} = 0; ${i} < ${sizeExpr}; ${i}++) {`);
+    if (typeof itemsType === 'object' && !Array.isArray(itemsType)) {
+        const elem = tmpId(ctx);
+        push(ctx, `const ${elem} = {};`);
+        generateReadObject(ctx, itemsType as Model, offsetVar, elem);
+        push(ctx, `${target}[${i}] = ${elem};`);
+    } else if (typeof itemsType === 'string') {
+        const elem = tmpId(ctx);
+        readField(ctx, itemsType, offsetVar, elem);
+        push(ctx, `${target}[${i}] = ${elem};`);
+    } else if (Array.isArray(itemsType)) {
+        const elem = tmpId(ctx);
+        push(ctx, `const ${elem} = [];`);
+        generateReadTuple(ctx, itemsType, offsetVar, elem, `${i}`);
+        push(ctx, `${target}[${i}] = ${elem};`);
+    } else {
+        throw new TypeError(`Unknown type "${itemsType}"`);
+    }
+    push(ctx, '}');
+}
+
+function writeArrayItems(
+    ctx: CodegenContext,
+    itemsType: Type,
+    structArrayExpr: string,
+    offsetVar: string,
+) {
+    const i = tmpId(ctx);
+    push(ctx, `for (let ${i} = 0; ${i} < ${structArrayExpr}.length; ${i}++) {`);
+    if (typeof itemsType === 'object' && !Array.isArray(itemsType)) {
+        generateWriteObject(ctx, itemsType as Model, offsetVar, `${structArrayExpr}[${i}]`);
+    } else if (typeof itemsType === 'string') {
+        writeField(ctx, itemsType, offsetVar, `${structArrayExpr}[${i}]`);
+    } else {
+        throw new TypeError(`Unknown type "${itemsType}"`);
+    }
+    push(ctx, '}');
+}
+
+function readDynamicOrStatic(
+    ctx: CodegenContext,
+    modelType: string,
+    dynamicLength: string,
+    readType: string,
+    offsetVar: string,
+    target: string,
+) {
+    const { specialType, isStatic, staticSize } = extractTypeAndSize(modelType, dynamicLength);
+    let sizeExpr: string;
+
+    if (isStatic) {
+        sizeExpr = String(staticSize);
+    } else {
+        sizeExpr = readLength(ctx, dynamicLength, offsetVar);
+    }
+
+    if (+sizeExpr === 0 && specialType === SpecialType.Buffer) {
+        throw new Error('Buffer size can not be 0.');
+    }
+
+    if (specialType) {
+        if (specialType === SpecialType.Json) {
+            const raw = tmpId(ctx);
+            if (isStatic && staticSize === 0) {
+                readStringUtf8Trailing(ctx, offsetVar, raw);
+            } else if (!isStatic) {
+                readStringUtf8(ctx, offsetVar, sizeExpr, raw);
+            } else {
+                readStringUtf8(ctx, offsetVar, sizeExpr, raw);
+            }
+            push(ctx, `${target} = JSON.parse(${raw});`);
+            return;
+        }
+        if (specialType === SpecialType.String) {
+            if (isStatic && staticSize === 0) {
+                readStringUtf8Trailing(ctx, offsetVar, target);
+            } else {
+                readStringUtf8(ctx, offsetVar, sizeExpr, target);
+            }
+            return;
+        }
+        if (specialType === SpecialType.WString) {
+            const byteSize = isStatic && staticSize > 0 ? `${staticSize * 2}` : `(${sizeExpr}) * 2`;
+            if (isStatic && staticSize === 0) {
+                readWStringTrailing(ctx, offsetVar, target);
+            } else {
+                readWString(ctx, offsetVar, byteSize, target);
+            }
+            return;
+        }
+        if (specialType === SpecialType.Buffer) {
+            readBuffer(ctx, offsetVar, sizeExpr, target);
+            return;
+        }
+    }
+
+    readArrayItems(ctx, readType, sizeExpr, offsetVar, target);
+}
+
+function writeDynamicOrStatic(
+    ctx: CodegenContext,
+    modelType: string,
+    dynamicLength: string,
+    structKeyExpr: string,
+    writeType: string,
+    offsetVar: string,
+) {
+    const { specialType, isStatic, staticSize } = extractTypeAndSize(modelType, dynamicLength);
+
+    let valueExpr = structKeyExpr;
+    if (specialType === SpecialType.Json) {
+        valueExpr = `JSON.stringify(${structKeyExpr})`;
+    }
+
+    if (isStatic && staticSize !== 0 && specialType !== SpecialType.String) {
+        push(ctx, `if (${structKeyExpr}.length > ${staticSize}) throw new Error('Size of value ' + ${structKeyExpr}.length + ' is greater than ${staticSize}.');`);
+    }
+
+    const sizeExpr = isStatic ? String(staticSize) : `${structKeyExpr}.length`;
+
+    if (+sizeExpr === 0 && specialType === SpecialType.Buffer) {
+        throw new Error('Buffer size can not be 0.');
+    }
+
+    if (!isStatic) {
+        writeLength(ctx, dynamicLength, offsetVar, sizeExpr);
+    }
+
+    if (specialType) {
+        if (specialType === SpecialType.String) {
+            if (isStatic && staticSize === 0) {
+                writeStringUtf8(ctx, offsetVar, structKeyExpr, 0, true);
+            } else if (!isStatic) {
+                writeStringUtf8(ctx, offsetVar, structKeyExpr, 0, false, true);
+            } else {
+                writeStringUtf8(ctx, offsetVar, structKeyExpr, staticSize);
+            }
+            return;
+        }
+        if (specialType === SpecialType.WString) {
+            if (isStatic && staticSize === 0) {
+                writeWString(ctx, offsetVar, structKeyExpr, 0, true);
+            } else if (!isStatic) {
+                const b = tmpId(ctx);
+                if (ctx.mode === 'make' && ctx.useChunks) {
+                    push(ctx, `{ const ${b} = Buffer.alloc((${structKeyExpr}).length * 2); ${b}.write(${structKeyExpr}, 0, 'utf16le'); chunks.push(${b}); }`);
+                } else {
+                    push(ctx, `{ const ${b} = (${structKeyExpr}).length * 2; buf.write(${structKeyExpr}, ${offsetVar}, ${b}, 'utf16le'); ${offsetVar} += ${b}; }`);
+                }
+            } else {
+                writeWString(ctx, offsetVar, structKeyExpr, staticSize);
+            }
+            return;
+        }
+        if (specialType === SpecialType.Buffer) {
+            if (isStatic) {
+                writeBufferField(ctx, offsetVar, structKeyExpr, staticSize);
+            } else {
+                throw new Error('Dynamic buffer without static size is not supported in write path.');
+            }
+            return;
+        }
+        if (specialType === SpecialType.Json) {
+            if (isStatic && staticSize === 0) {
+                writeStringUtf8(ctx, offsetVar, valueExpr, 0, true);
+            } else if (!isStatic) {
+                writeStringUtf8(ctx, offsetVar, valueExpr, 0, false, true);
+            } else {
+                writeStringUtf8(ctx, offsetVar, valueExpr, staticSize);
+            }
+            return;
+        }
+    }
+
+    writeArrayItems(ctx, writeType, structKeyExpr, offsetVar);
+}
+
+function readField(ctx: CodegenContext, modelType: Type, offsetVar: string, target: string) {
+    if (Array.isArray(modelType)) {
+        push(ctx, `${target} = [];`);
+        generateReadTuple(ctx, modelType, offsetVar, target, '');
+        return;
+    }
+
+    if (typeof modelType === 'string') {
+        const typeGroups = getDotGroups(modelType);
+        if (typeGroups) {
+            readDynamicOrStatic(
+                ctx,
+                typeGroups.dynamicType,
+                typeGroups.dynamicLength,
+                typeGroups.dynamicType,
+                offsetVar,
+                target,
+            );
+            return;
+        }
+        readScalarType(ctx, modelType, offsetVar, target);
+        return;
+    }
+
+    if (typeof modelType === 'object') {
+        push(ctx, `${target} = {};`);
+        generateReadObject(ctx, modelType as Model, offsetVar, target);
+        return;
+    }
+
+    throw new TypeError(`Unknown type "${modelType}"`);
+}
+
+function writeField(ctx: CodegenContext, modelType: Type, offsetVar: string, valueExpr: string) {
+    if (Array.isArray(modelType)) {
+        for (let i = 0; i < modelType.length; i++) {
+            writeField(ctx, modelType[i], offsetVar, `${valueExpr}[${i}]`);
+        }
+        return;
+    }
+
+    if (typeof modelType === 'object' && !Array.isArray(modelType)) {
+        generateWriteObject(ctx, modelType as Model, offsetVar, valueExpr);
+        return;
+    }
+
+    if (typeof modelType === 'string') {
+        const typeGroups = getDotGroups(modelType);
+        if (typeGroups) {
+            writeDynamicOrStatic(
+                ctx,
+                typeGroups.dynamicType,
+                typeGroups.dynamicLength,
+                valueExpr,
+                typeGroups.dynamicType,
+                offsetVar,
+            );
+            return;
+        }
+        writeScalarType(ctx, modelType, offsetVar, valueExpr);
+        return;
+    }
+
+    throw new TypeError(`Unknown type "${modelType}"`);
+}
+
+type TupleModel = ModelValue[];
+
+function generateReadTuple(
+    ctx: CodegenContext,
+    model: TupleModel,
+    offsetVar: string,
+    target: string,
+    indexPrefix: string,
+) {
+    for (let i = 0; i < model.length; i++) {
+        const itemType = model[i];
+        const idx = indexPrefix ? `${indexPrefix}[${i}]` : String(i);
+        const elem = tmpId(ctx);
+        readField(ctx, itemType as Type, offsetVar, elem);
+        push(ctx, `${target}[${idx}] = ${elem};`);
+    }
+}
+
+function generateReadObject(ctx: CodegenContext, model: Model, offsetVar: string, target: string) {
+    if (Array.isArray(model)) {
+        generateReadTuple(ctx, model as ModelValue[], offsetVar, target, '');
+        return;
+    }
+
+    for (const [modelKey, modelType] of Object.entries(model)) {
+        const keyGroups = getDotGroups(modelKey);
+        if (keyGroups) {
+            const { dynamicType, dynamicLength } = keyGroups;
+            const val = tmpId(ctx);
+            readDynamicOrStatic(
+                ctx,
+                modelType as string,
+                dynamicLength,
+                modelType as string,
+                offsetVar,
+                val,
+            );
+            push(ctx, `${target}.${dynamicType} = ${val};`);
+            continue;
+        }
+
+        if (typeof modelType === 'string') {
+            const typeGroups = getDotGroups(modelType);
+            if (typeGroups) {
+                const val = tmpId(ctx);
+                readDynamicOrStatic(
+                    ctx,
+                    typeGroups.dynamicType,
+                    typeGroups.dynamicLength,
+                    typeGroups.dynamicType,
+                    offsetVar,
+                    val,
+                );
+                push(ctx, `${target}.${modelKey} = ${val};`);
+                continue;
+            }
+        }
+
+        const val = tmpId(ctx);
+        readField(ctx, modelType, offsetVar, val);
+        push(ctx, `${target}.${modelKey} = ${val};`);
+    }
+}
+
+function generateWriteObject(ctx: CodegenContext, model: Model, offsetVar: string, structExpr: string) {
+    if (Array.isArray(model)) {
+        for (let i = 0; i < model.length; i++) {
+            writeField(ctx, model[i], offsetVar, `${structExpr}[${i}]`);
+        }
+        return;
+    }
+
+    for (const [modelKey, modelType] of Object.entries(model)) {
+        const keyGroups = getDotGroups(modelKey);
+        if (keyGroups) {
+            const { dynamicType, dynamicLength } = keyGroups;
+            writeDynamicOrStatic(
+                ctx,
+                modelType as string,
+                dynamicLength,
+                `${structExpr}.${dynamicType}`,
+                modelType as string,
+                offsetVar,
+            );
+            continue;
+        }
+
+        if (typeof modelType === 'string') {
+            const typeGroups = getDotGroups(modelType);
+            if (typeGroups) {
+                writeDynamicOrStatic(
+                    ctx,
+                    typeGroups.dynamicType,
+                    typeGroups.dynamicLength,
+                    `${structExpr}.${modelKey}`,
+                    typeGroups.dynamicType,
+                    offsetVar,
+                );
+                continue;
+            }
+        }
+
+        writeField(ctx, modelType, offsetVar, `${structExpr}.${modelKey}`);
+    }
+}
+
+function createContext(endian: Endian, mode: CodegenMode, useChunks: boolean): CodegenContext {
+    return { endian, mode, lines: [], counter: 0, useChunks };
+}
+
+export function generateReadBody(model: Model, endian: Endian): string {
+    const ctx = createContext(endian, 'read', false);
+    push(ctx, 'off = off || 0;');
+    push(ctx, 'let o = off;');
+    const root = tmpId(ctx);
+    if (Array.isArray(model)) {
+        push(ctx, `const ${root} = [];`);
+        generateReadTuple(ctx, model as ModelValue[], 'o', root, '');
+        push(ctx, `return { struct: ${root}, offset: o, size: o - off };`);
+    } else {
+        push(ctx, `const ${root} = {};`);
+        generateReadObject(ctx, model, 'o', root);
+        push(ctx, `return { struct: ${root}, offset: o, size: o - off };`);
+    }
+    return ctx.lines.join('\n');
+}
+
+export function generateWriteBody(model: Model, endian: Endian): string {
+    const ctx = createContext(endian, 'write', false);
+    push(ctx, 'off = off || 0;');
+    push(ctx, 'let o = off;');
+    if (Array.isArray(model)) {
+        generateWriteObject(ctx, model, 'o', 'struct');
+    } else {
+        generateWriteObject(ctx, model, 'o', 'struct');
+    }
+    push(ctx, 'const written = o - off;');
+    push(ctx, 'if (written > buf.length - off) throw new Error("Write buffer is too short. Needs " + (written - (buf.length - off)) + " byte/s more.");');
+    push(ctx, 'return { buffer: buf, offset: o, size: written };');
+    return ctx.lines.join('\n');
+}
+
+export function generateMakeBody(model: Model, endian: Endian, useChunks: boolean, staticSize: number): string {
+    const ctx = createContext(endian, 'make', useChunks);
+    if (useChunks) {
+        push(ctx, 'const chunks = [];');
+        push(ctx, 'let o = 0;');
+        generateWriteObject(ctx, model, 'o', 'struct');
+        push(ctx, 'const buffer = Buffer.concat(chunks);');
+        push(ctx, 'return { buffer, offset: buffer.length, size: buffer.length };');
+    } else {
+        push(ctx, `const buf = Buffer.allocUnsafe(${staticSize});`);
+        push(ctx, 'let o = 0;');
+        generateWriteObject(ctx, model, 'o', 'struct');
+        push(ctx, 'return { buffer: buf, offset: o, size: o };');
+    }
+    return ctx.lines.join('\n');
+}

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './compile';

--- a/src/codegen/model-analyzer.ts
+++ b/src/codegen/model-analyzer.ts
@@ -1,0 +1,119 @@
+import { Model, Type } from '../types';
+import { getAtomSize } from './atom-spec';
+import { extractTypeAndSize, getDotGroups, getSpecialType, isVariableField, parseSizedAtom } from './type-utils';
+import { ModelAnalysis } from './types';
+
+function fieldStaticSize(modelKey: string, modelType: Type): number | undefined {
+    const keyGroups = getDotGroups(modelKey);
+    if (keyGroups) {
+        const { specialType, isStatic, staticSize } = extractTypeAndSize(
+            modelType as string,
+            keyGroups.dynamicLength,
+        );
+        if (!isStatic || staticSize === 0) return undefined;
+        if (specialType) {
+            if (getSpecialType(modelType as string) !== undefined) {
+                const base = modelType as string;
+                if (base === 'ws' || base.startsWith('ws')) return staticSize * 2;
+            }
+            const sized = parseSizedAtom(modelType as string);
+            if (sized?.base === 'ws') return staticSize * 2;
+            return staticSize;
+        }
+        const atom = getAtomSize(modelType as string);
+        return atom !== undefined ? atom * staticSize : undefined;
+    }
+
+    if (Array.isArray(modelType)) {
+        let total = 0;
+        for (const item of modelType) {
+            const s = fieldSizeFromType(item);
+            if (s === undefined) return undefined;
+            total += s;
+        }
+        return total;
+    }
+
+    return fieldSizeFromType(modelType);
+}
+
+function fieldSizeFromType(modelType: Type): number | undefined {
+    if (typeof modelType === 'object' && !Array.isArray(modelType)) {
+        let total = 0;
+        for (const [k, t] of Object.entries(modelType)) {
+            const s = fieldStaticSize(k, t);
+            if (s === undefined) return undefined;
+            total += s;
+        }
+        return total;
+    }
+
+    if (Array.isArray(modelType)) {
+        let total = 0;
+        for (const item of modelType) {
+            const s = fieldSizeFromType(item);
+            if (s === undefined) return undefined;
+            total += s;
+        }
+        return total;
+    }
+
+    if (typeof modelType !== 'string') return undefined;
+
+    const typeGroups = getDotGroups(modelType);
+    if (typeGroups) {
+        const { isStatic, staticSize } = extractTypeAndSize(
+            typeGroups.dynamicType,
+            typeGroups.dynamicLength,
+        );
+        if (!isStatic) return undefined;
+        if (staticSize === 0) return undefined;
+        const atom = getAtomSize(typeGroups.dynamicType);
+        if (atom === undefined) {
+            const sized = parseSizedAtom(typeGroups.dynamicType);
+            if (sized) {
+                const byteSize = sized.base === 'ws' ? sized.size * 2 : sized.size;
+                return byteSize * staticSize;
+            }
+            return undefined;
+        }
+        return atom * staticSize;
+    }
+
+    const atom = getAtomSize(modelType);
+    if (atom !== undefined) return atom;
+
+    const sized = parseSizedAtom(modelType);
+    if (sized) {
+        if (sized.size === 0) return undefined;
+        return sized.base === 'ws' ? sized.size * 2 : sized.size;
+    }
+
+    if (modelType === 'j0') return undefined;
+
+    return undefined;
+}
+
+function walkVariable(model: Model): boolean {
+    if (Array.isArray(model)) {
+        for (const item of model) {
+            if (typeof item === 'string' && isVariableField('', item)) return true;
+            if (typeof item === 'object' && walkVariable(item as Model)) return true;
+        }
+        return false;
+    }
+
+    for (const [key, type] of Object.entries(model)) {
+        if (isVariableField(key, type)) return true;
+        if (typeof type === 'object') {
+            if (walkVariable(type as Model)) return true;
+        }
+    }
+    return false;
+}
+
+export function analyzeModel(model: Model): ModelAnalysis {
+    const hasVariableLength = walkVariable(model);
+    const staticSize = hasVariableLength ? 0 : (fieldSizeFromType(model) ?? 0);
+    return { hasVariableLength, staticSize };
+}

--- a/src/codegen/type-utils.ts
+++ b/src/codegen/type-utils.ts
@@ -1,0 +1,75 @@
+import { SpecialType, Type } from '../types';
+
+const DYNAMIC_DOT = /^(?<dynamicType>\w+)\.(?<dynamicLength>\w+)$/;
+const SIZED_ATOM = /^(?<base>s|ws|buf|j)(?<size>\d+)$/;
+
+export interface DotGroups {
+    dynamicType: string;
+    dynamicLength: string;
+}
+
+export function getDotGroups(key: string): DotGroups | undefined {
+    const groups = key.match(DYNAMIC_DOT)?.groups;
+    if (!groups?.dynamicType || !groups?.dynamicLength) return undefined;
+    return { dynamicType: groups.dynamicType, dynamicLength: groups.dynamicLength };
+}
+
+export function getSpecialType(base: string): SpecialType | undefined {
+    switch (base) {
+        case 's':
+        case 'string':
+            return SpecialType.String;
+        case 'ws':
+        case 'wstring':
+            return SpecialType.WString;
+        case 'buf':
+        case 'buffer':
+            return SpecialType.Buffer;
+        case 'j':
+        case 'json':
+        case 'any':
+            return SpecialType.Json;
+        default:
+            return undefined;
+    }
+}
+
+export function parseSizedAtom(type: string): { base: string; size: number } | undefined {
+    const m = type.match(SIZED_ATOM);
+    if (!m?.groups) return undefined;
+    return { base: m.groups.base, size: +m.groups.size };
+}
+
+export function isLengthNumeric(length: string): boolean {
+    return !Number.isNaN(+length);
+}
+
+export function extractTypeAndSize(modelType: string, dynamicLength: string) {
+    const specialType = getSpecialType(modelType);
+    const n = +dynamicLength;
+    const isStatic = !Number.isNaN(n);
+    return { specialType, isStatic, staticSize: n };
+}
+
+export function isDynamicLengthType(length: string): boolean {
+    return !isLengthNumeric(length);
+}
+
+export function isVariableField(modelKey: string, modelType: Type): boolean {
+    const keyGroups = getDotGroups(modelKey);
+    if (keyGroups) {
+        const { staticSize } = extractTypeAndSize(modelType as string, keyGroups.dynamicLength);
+        return staticSize === 0 || isDynamicLengthType(keyGroups.dynamicLength);
+    }
+    if (typeof modelType === 'string') {
+        const typeGroups = getDotGroups(modelType);
+        if (typeGroups) {
+            return !isLengthNumeric(typeGroups.dynamicLength)
+                || +typeGroups.dynamicLength === 0;
+        }
+        const sized = parseSizedAtom(modelType);
+        if (sized && sized.size === 0) return true;
+        if (modelType === 'j0') return true;
+    }
+    return false;
+}

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -18,6 +18,8 @@ export interface CodegenContext {
     lines: string[];
     counter: number;
     useChunks: boolean;
+    /** When true (make mode), emit `size += …` instead of buffer writes. */
+    accumulateSize?: boolean;
 }
 
 export type ParsedModel = Model;

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -1,0 +1,23 @@
+import { CStructReadResult, CStructWriteResult, Model } from '../types';
+
+export type Endian = 'le' | 'be';
+export type CodegenMode = 'read' | 'write' | 'make';
+
+export type CompiledReadFn<T = unknown> = (buf: Buffer, off?: number) => CStructReadResult<T>;
+export type CompiledWriteFn<T = unknown> = (struct: T, buf: Buffer, off?: number) => CStructWriteResult;
+export type CompiledMakeFn<T = unknown> = (struct: T) => CStructWriteResult;
+
+export interface ModelAnalysis {
+    hasVariableLength: boolean;
+    staticSize: number;
+}
+
+export interface CodegenContext {
+    endian: Endian;
+    mode: CodegenMode;
+    lines: string[];
+    counter: number;
+    useChunks: boolean;
+}
+
+export type ParsedModel = Model;

--- a/src/cstruct-be.ts
+++ b/src/cstruct-be.ts
@@ -5,6 +5,17 @@ import { WriteBE } from "./write-be";
 import { ReadBE } from "./read-be";
 import { CStructMetadata } from "./decorators-metadata";
 import { Class, CStructClassOptions } from "./decorators-types";
+import {
+    compileMakeFromParsedModel,
+    compileReadFromParsedModel,
+    compileWriteFromParsedModel,
+    compileMake,
+    compileRead,
+    compileWrite,
+    CompiledMakeFn,
+    CompiledReadFn,
+    CompiledWriteFn,
+} from "./codegen";
 
 /**
  * C_Struct BE - Big Endian
@@ -75,5 +86,29 @@ export class CStructBE<T> extends CStruct<T> {
     static fromCompiled<T = any>(jsonModel: string | Model): CStructBE<T> {
         const normalized = CStruct.normalizeCompiledJsonModel(jsonModel);
         return new CStructBE<T>(undefined, undefined, normalized);
+    }
+
+    compileRead<T = any>(): CompiledReadFn<T> {
+        return compileReadFromParsedModel<T>(this.parsedModel, 'be');
+    }
+
+    compileWrite<T = any>(): CompiledWriteFn<T> {
+        return compileWriteFromParsedModel<T>(this.parsedModel, 'be');
+    }
+
+    compileMake<T = any>(): CompiledMakeFn<T> {
+        return compileMakeFromParsedModel<T>(this.parsedModel, 'be');
+    }
+
+    static compileRead<T = any>(model: Model, types?: Types): CompiledReadFn<T> {
+        return compileRead<T>(model, types, 'be');
+    }
+
+    static compileWrite<T = any>(model: Model, types?: Types): CompiledWriteFn<T> {
+        return compileWrite<T>(model, types, 'be');
+    }
+
+    static compileMake<T = any>(model: Model, types?: Types): CompiledMakeFn<T> {
+        return compileMake<T>(model, types, 'be');
     }
 }

--- a/src/cstruct-le.ts
+++ b/src/cstruct-le.ts
@@ -5,6 +5,17 @@ import { WriteLE } from "./write-le";
 import { ReadLE } from "./read-le";
 import { CStructMetadata } from "./decorators-metadata";
 import { Class, CStructClassOptions } from "./decorators-types";
+import {
+    compileMakeFromParsedModel,
+    compileReadFromParsedModel,
+    compileWriteFromParsedModel,
+    compileMake,
+    compileRead,
+    compileWrite,
+    CompiledMakeFn,
+    CompiledReadFn,
+    CompiledWriteFn,
+} from "./codegen";
 
 /**
  * C_Struct LE - Little Endian
@@ -75,5 +86,29 @@ export class CStructLE<T> extends CStruct<T> {
     static fromCompiled<T = any>(jsonModel: string | Model): CStructLE<T> {
         const normalized = CStruct.normalizeCompiledJsonModel(jsonModel);
         return new CStructLE<T>(undefined, undefined, normalized);
+    }
+
+    compileRead<T = any>(): CompiledReadFn<T> {
+        return compileReadFromParsedModel<T>(this.parsedModel, 'le');
+    }
+
+    compileWrite<T = any>(): CompiledWriteFn<T> {
+        return compileWriteFromParsedModel<T>(this.parsedModel, 'le');
+    }
+
+    compileMake<T = any>(): CompiledMakeFn<T> {
+        return compileMakeFromParsedModel<T>(this.parsedModel, 'le');
+    }
+
+    static compileRead<T = any>(model: Model, types?: Types): CompiledReadFn<T> {
+        return compileRead<T>(model, types, 'le');
+    }
+
+    static compileWrite<T = any>(model: Model, types?: Types): CompiledWriteFn<T> {
+        return compileWrite<T>(model, types, 'le');
+    }
+
+    static compileMake<T = any>(model: Model, types?: Types): CompiledMakeFn<T> {
+        return compileMake<T>(model, types, 'le');
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from './cstruct-le';
 export * from './decorators';
 export * from './decorators-types';
 export * from './atom-types';
+export * from './codegen';

--- a/tests/codegen.test.ts
+++ b/tests/codegen.test.ts
@@ -106,6 +106,18 @@ describe('codegen parity', () => {
             expectCodegenParity(CStruct, model, undefined, struct);
         });
 
+        it('dynamic string s[i16] non-ascii', () => {
+            const model = { txt: 's[i16]' };
+            const struct = { txt: 'ąę' };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('dynamic json j[i16]', () => {
+            const model = { any1: 'j[i16]' };
+            const struct = { any1: { a: 1, b: [2, 3] } };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
         it('trailing zero s[0]', () => {
             const model = { any1: 's[0]' };
             const struct = { any1: 'abc' };
@@ -164,6 +176,23 @@ describe('codegen parity', () => {
             const writeFn = CStruct.compileWrite(model);
             const buf = Buffer.alloc(4);
             expect(() => writeFn({ r: 1 }, buf, 3)).toThrow();
+        });
+
+        it('write buffer too short does not mutate target buffer', () => {
+            const model = { r: 'u16' };
+            const writeFn = CStruct.compileWrite(model);
+            const buf = Buffer.alloc(8);
+            buf.fill(0xaa);
+            const before = Buffer.from(buf);
+            expect(() => writeFn({ r: 0x1234 }, buf, 7)).toThrow();
+            expect(buf).toEqual(before);
+        });
+
+        it('bracket notation for unusual field keys', () => {
+            const model = { '__proto__': 'u16' };
+            const struct = { '__proto__': 42 };
+            expectCodegenParity(CStruct, model, undefined, struct);
+            expect(Object.prototype).not.toHaveProperty('42');
         });
     });
 });

--- a/tests/codegen.test.ts
+++ b/tests/codegen.test.ts
@@ -1,0 +1,169 @@
+import { CStructBE, CStructLE, hexToBuffer } from '../src';
+
+type CStructApi = typeof CStructBE | typeof CStructLE;
+
+function expectCodegenParity(
+    CStruct: CStructApi,
+    model: object | string | string[],
+    types: object | undefined,
+    struct: unknown,
+    buffer?: Buffer,
+    offset = 0,
+) {
+    const cStruct = CStruct.fromModelTypes(model as never, types as never);
+
+    const readFn = CStruct.compileRead(model as never, types as never);
+    const writeFn = CStruct.compileWrite(model as never, types as never);
+    const makeFn = CStruct.compileMake(model as never, types as never);
+
+    const instanceReadFn = cStruct.compileRead();
+    const instanceWriteFn = cStruct.compileWrite();
+    const instanceMakeFn = cStruct.compileMake();
+
+    const made = cStruct.make(struct as never);
+    const madeCodegen = makeFn(struct as never);
+    const madeInstance = instanceMakeFn(struct as never);
+
+    expect(madeCodegen).toEqual(made);
+    expect(madeInstance).toEqual(made);
+
+    const readBuf = buffer ?? made.buffer;
+    const readExpected = cStruct.read(readBuf, offset);
+    const readCodegen = readFn(readBuf, offset);
+    const readInstance = instanceReadFn(readBuf, offset);
+
+    expect(readCodegen).toEqual(readExpected);
+    expect(readInstance).toEqual(readExpected);
+
+    const writeTarget = Buffer.alloc(Math.max(readBuf.length, made.buffer.length + offset + 16));
+    const writeExpected = cStruct.write(writeTarget, struct as never, offset);
+    const writeCopy = Buffer.alloc(writeTarget.length);
+    const writeCodegen = writeFn(struct as never, writeCopy, offset);
+    const writeInstanceCopy = Buffer.alloc(writeTarget.length);
+    const writeInstance = instanceWriteFn(struct as never, writeInstanceCopy, offset);
+
+    expect(writeCopy).toEqual(writeExpected.buffer);
+    expect(writeCodegen).toEqual(writeExpected);
+    expect(writeInstance).toEqual(writeExpected);
+}
+
+describe('codegen parity', () => {
+    describe.each([
+        ['BE', CStructBE],
+        ['LE', CStructLE],
+    ] as const)('%s', (_label, CStruct) => {
+        it('scalars u16 i32 b8', () => {
+            const model = { x: 'u16', y: 'i32', flag: 'b8' };
+            const struct = { x: 0x1234, y: -7, flag: true };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('fixed string s5', () => {
+            const model = { r: 's5' };
+            const struct = { r: 'abc' };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('static array tuple', () => {
+            const model = { r: ['u16', 'u16'] };
+            const struct = { r: [0x1234, 0x5678] };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('root tuple model', () => {
+            const model = ['u16', 'u16'];
+            const struct = [0x1234, 0x5678];
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('nested struct', () => {
+            const model = { error: { code: 'u16', message: 's5' } };
+            const struct = { error: { code: 10, message: 'abc' } };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('dynamic u16 array', () => {
+            const model = { r: 'u16[i16]' };
+            const struct = { r: [0x1234, 0x5678] };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('dynamic nested type array', () => {
+            const model = { ab: 'Ab[i16]' };
+            const types = { Ab: { a: 'i8', b: 'i8' } };
+            const struct = {
+                ab: [
+                    { a: -1, b: 1 },
+                    { a: -2, b: 2 },
+                ],
+            };
+            expectCodegenParity(CStruct, model, types, struct);
+        });
+
+        it('dynamic string s[i16]', () => {
+            const model = { txt: 's[i16]' };
+            const struct = { txt: 'ABCDE' };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('trailing zero s[0]', () => {
+            const model = { any1: 's[0]' };
+            const struct = { any1: 'abc' };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('trailing zero j[0]', () => {
+            const model = { any1: 'j[0]' };
+            const struct = { any1: { a: 1, b: [2, 3] } };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('tuple with static and dynamic arrays', () => {
+            const model = ['i8', 'i8[2]', 'i8[i16]'];
+            const struct = [0x01, [0x02, 0x03], [0x04, 0x05, 0x06, 0x07]];
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('buffer field buf4', () => {
+            const model = { b: 'buf4' };
+            const struct = { b: hexToBuffer('01020304') };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('json field j20', () => {
+            const model = { j: 'j[20]' };
+            const struct = { j: { a: 1 } };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('PLC aliases', () => {
+            const model = { b: 'BYTE', w: 'WORD', f: 'BOOL' };
+            const struct = { b: 0x12, w: 0x3456, f: true };
+            expectCodegenParity(CStruct, model, undefined, struct);
+        });
+
+        it('read with offset', () => {
+            const model = { r: 'u16' };
+            const cStruct = CStruct.fromModelTypes(model);
+            const readFn = CStruct.compileRead(model);
+            const buffer = hexToBuffer('0000 1234');
+            const expected = cStruct.read(buffer, 2);
+            expect(readFn(buffer, 2)).toEqual(expected);
+        });
+
+        it('fromCompiled instance compileRead', () => {
+            const model = { a: 'u16', b: 'i16' };
+            const cStruct = CStruct.fromModelTypes(model);
+            const fromCompiled = CStruct.fromCompiled(cStruct.jsonModel);
+            const buffer = cStruct.make({ a: 10, b: -10 }).buffer;
+            expect(fromCompiled.compileRead()(buffer)).toEqual(cStruct.read(buffer));
+        });
+
+        it('write buffer too short throws', () => {
+            const model = { r: 'u16' };
+            const writeFn = CStruct.compileWrite(model);
+            const buf = Buffer.alloc(4);
+            expect(() => writeFn({ r: 1 }, buf, 3)).toThrow();
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add `compileRead`, `compileWrite`, `compileMake` static methods on `CStructBE` and `CStructLE`
- Add instance methods `cStruct.compileRead()` / `compileWrite()` / `compileMake()` using cached `parsedModel`
- New `src/codegen/` module generates specialized functions via `new Function` with full parity vs interpreter
- `compileMake` hybrid: `allocUnsafe(size)` for static models, `chunks + concat` for variable-length fields
- Existing `read` / `write` / `make` unchanged

## Test plan
- [x] `npm run build`
- [x] `npm test` (648 tests, including `tests/codegen.test.ts` parity BE+LE)
- [x] `npm run lint`
- [x] `examples/codegen.ts` added
- [x] README section + changelog 1.7.0


Made with [Cursor](https://cursor.com)