### PR TITLE
Release 1.7.2: fix npm publish build hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,6 +919,9 @@ Full index: [`examples/README.md`](https://github.com/MrHIDEn/cstruct/blob/main/
 
 ## Changelog
 
+### What's new in 1.7.2
+* Fixed publish hook: `prepublishOnly` runs `tsc` before `npm publish` (replaces deprecated `prepublish`, which no longer builds on publish)
+
 ### What's new in 1.7.1
 * Codegen fixes: correct dynamic `j[i16]` / `s[i16]` length prefixes, `compileWrite` validates buffer size before writing, bracket notation for model field access (safer `new Function` codegen)
 * Optimized dynamic `compileMake` — size precompute + single `allocUnsafe` (~×41 vs interpreter on dynamic make)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mrhiden/cstruct",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "For packing and unpacking bytes (C like structures) in/from Buffer based on Object/Array type for parsing.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -37,7 +37,7 @@
     "bench": "ts-node --transpile-only ./benchmarks/codegen-bench.ts",
     "bench:bun": "bun ./benchmarks/codegen-bench.ts",
     "model-parser": "ts-node-dev --transpile-only ./src/model-parser.ts",
-    "prepublish": "tsc",
+    "prepublishOnly": "tsc",
     "build": "tsc",
     "test": "jest",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary
- Replace deprecated `prepublish` with `prepublishOnly: tsc` so `npm publish` always builds `lib/` before packing
- Bump version to **1.7.2**

## Why
`prepublish` no longer runs on `npm publish` (npm v5+). Without `prepublishOnly`, publishing could ship an empty or stale `lib/` because sources live in `src/` and `lib/` is gitignored.

## Test plan
- [x] `npm run build` passes locally
- [x] `npm pack --dry-run` includes `lib/**`
- [ ] After merge: `npm publish --access public` from clean checkout


Made with [Cursor](https://cursor.com)